### PR TITLE
UI 카메라 버그 해결(원인: 레지스터 번호 겹침)

### DIFF
--- a/Engine_SOURCE/UICanvas_InGame.cpp
+++ b/Engine_SOURCE/UICanvas_InGame.cpp
@@ -26,6 +26,11 @@ namespace ya
 		AddComponent<UIHPBarScript>();
 	}
 
+	void UICanvas_InGame::Render()
+	{
+
+	}
+
 
 	void UICanvas_InGame::CreateHP_HUD()
 	{

--- a/Engine_SOURCE/UICanvas_InGame.h
+++ b/Engine_SOURCE/UICanvas_InGame.h
@@ -24,6 +24,8 @@ namespace ya
 
         virtual void Initialize() override;
 
+        virtual void Render() override;
+
     private:
         void CreateHP_HUD();
         void CreateGeneralHUD();

--- a/Engine_SOURCE/yaTitleScene.cpp
+++ b/Engine_SOURCE/yaTitleScene.cpp
@@ -90,6 +90,10 @@ namespace ya
 			cameraComp->DisableLayerMasks();
 			cameraComp->TurnLayerMask(eLayerType::UI, true);
 		}
+		{
+			UICanvas_InGame* ui = object::Instantiate<UICanvas_InGame>(eLayerType::UI);
+			ui->SetName(L"UICanvasObj_InGame");
+		}
 
 		{
 			GameObject* wall = object::Instantiate<GameObject>(eLayerType::Wall);
@@ -105,12 +109,7 @@ namespace ya
 			wallCollider->SetType(eColliderType::Box);
 			wallCollider->SetSize(Vector3(1.0f, 1.0f, 1.0f));
 			wall->AddComponent<WallScript>();
-		{
-			UICanvas_InGame* ui = object::Instantiate<UICanvas_InGame>(eLayerType::UI);
-			ui->SetName(L"UICanvasObj_InGame");
 
-
-		}
 
 		//{
 

--- a/SHADER_SOURCE/ConstantBuffer.hlsli
+++ b/SHADER_SOURCE/ConstantBuffer.hlsli
@@ -66,7 +66,7 @@ cbuffer ParticleSystem : register(b5)
 //    float4 NoiseSize;
 //}
 
-cbuffer UniformDataCB : register(b8)
+cbuffer UniformDataCB : register(b9)
 {
 	int int_0;
 	int int_1;


### PR DESCRIPTION
UI 상수버퍼 레지스터 번호 8번에서 9번으로 변경