### PR TITLE
- threadpool 오류 수정

### DIFF
--- a/44Engine/main.cpp
+++ b/44Engine/main.cpp
@@ -18,13 +18,9 @@
 #pragma comment(lib, "..\\x64\\Release\\Lib\\Engine_SOURCE.lib") 
 #endif
 
-
-
-
-#ifdef _DEBUG
-#pragma comment(linker, "/entry:wWinMainCRTStartup /subsystem:console")
-#endif
-
+//#ifdef _DEBUG
+//#pragma comment(linker, "/entry:wWinMainCRTStartup /subsystem:console")
+//#endif
 
 #define MAX_LOADSTRING 100
 

--- a/Engine_SOURCE/MapObjects.cpp
+++ b/Engine_SOURCE/MapObjects.cpp
@@ -16,8 +16,6 @@ namespace ya
 
 	MapObjects::~MapObjects()
 	{
-
-
 	}
 
 	void MapObjects::Initialize()
@@ -79,7 +77,7 @@ namespace ya
 		std::shared_ptr<MeshData> meshdata = Resources::Load<MeshData>(mapMeshPath.filename(), mapMeshPath);
 		assert(nullptr != meshdata);
 
-		GameObject* obj = meshdata->Instantiate(eLayerType::Ground);
+		GameObject* obj = meshdata->Instantiate(eLayerType::Ground, GetScene());
 		Transform* myTr = GetComponent<Transform>();
 		Transform* childTr = obj->GetComponent<Transform>();
 		childTr->SetParent(myTr);

--- a/Engine_SOURCE/UIHPBarScript.cpp
+++ b/Engine_SOURCE/UIHPBarScript.cpp
@@ -20,7 +20,7 @@ namespace ya
 
 	void UIHPBarScript::Update()
 	{
-		Scene* scene = SceneManager::GetActiveScene();
+		Scene* scene = GetOwner()->GetScene();
 		if (scene)
 		{
 			mPlayer = scene->GetPlayer();

--- a/Engine_SOURCE/yaActionScript.cpp
+++ b/Engine_SOURCE/yaActionScript.cpp
@@ -53,7 +53,7 @@ namespace ya
 		mRigidbody = obj->GetComponent<Rigidbody>();
 		mCollider = obj->GetComponent<Collider2D>();
 
-		WallCheckObject* checkObj = object::Instantiate<WallCheckObject>(eLayerType::WallCheckCollision);
+		WallCheckObject* checkObj = object::Instantiate<WallCheckObject>(eLayerType::WallCheckCollision, obj->GetScene());
 		assert(checkObj != nullptr);
 		mCheck = checkObj;
 		checkObj->SetName(L"WallCheck");

--- a/Engine_SOURCE/yaCamera.cpp
+++ b/Engine_SOURCE/yaCamera.cpp
@@ -215,7 +215,8 @@ namespace ya
 
 	void Camera::RegisterCameraInRenderer()
 	{
-		eSceneType type = SceneManager::GetActiveScene()->GetSceneType();
+		//eSceneType type = SceneManager::GetActiveScene()->GetSceneType();
+		eSceneType type = GetOwner()->GetScene()->GetSceneType();
 		renderer::cameras[(UINT)type].push_back(this);
 	}
 
@@ -232,7 +233,8 @@ namespace ya
 		mTransparentGameObjects.clear();
 		mPostProcessGameObjects.clear();
 
-		Scene* scene = SceneManager::GetActiveScene();
+		//Scene* scene = SceneManager::GetActiveScene();
+		Scene* scene = GetOwner()->GetScene();
 		for (size_t i = 0; i < (UINT)eLayerType::End; i++)
 		{
 			if (mLayerMasks[i] == true)

--- a/Engine_SOURCE/yaCameraScript.cpp
+++ b/Engine_SOURCE/yaCameraScript.cpp
@@ -314,7 +314,8 @@ namespace ya
 		//장애물을 고려할때, 사실 일부분만 보여도 락온이 되던데. 레이를 여러방 쏴야하나??
 		//락온 대상이 장애물 등에 완전히 가려지거나 너무 멀어지면 락온이 풀려야한다.
 
-		Scene* scene =  SceneManager::GetActiveScene();
+		//Scene* scene =  SceneManager::GetActiveScene();
+		Scene* scene = GetOwner()->GetScene();
 		std::vector<GameObject*> mons =  scene->GetGameObjects(eLayerType::Monster);
 		float minDist = 10000000;
 		Transform* tr = GetOwner()->GetComponent<Transform>();

--- a/Engine_SOURCE/yaCollisionManager.cpp
+++ b/Engine_SOURCE/yaCollisionManager.cpp
@@ -360,7 +360,8 @@ namespace ya
 
 	RayHit CollisionManager::RayCast(GameObject* owner, Vector3 direction, std::vector<eLayerType> layers)
 	{
-		Scene* scene = SceneManager::GetActiveScene();
+		//Scene* scene = SceneManager::GetActiveScene();
+		Scene* scene = owner->GetScene();
 		Matrix worldMat = owner->GetComponent<Transform>()->GetWorldMatrix();
 		Vector3 position = Vector3(worldMat._41, worldMat._42, worldMat._43);
 		ya::Ray ray = ya::Ray(position, direction);
@@ -395,7 +396,8 @@ namespace ya
 
 	RayHit CollisionManager::RayCast(GameObject* owner, Vector3 position, Vector3 direction, float length, std::vector<eLayerType> layers)
 	{
-		Scene* scene = SceneManager::GetActiveScene();
+		//Scene* scene = SceneManager::GetActiveScene();
+		Scene* scene = owner->GetScene();
 		ya::Ray ray = ya::Ray(position, direction);
 
 		RayHit hit = RayHit(false, nullptr, Vector3::Zero);
@@ -430,7 +432,8 @@ namespace ya
 
 	RayHit CollisionManager::RayCast(GameObject* owner, Vector3 position, Vector3 direction, std::vector<eLayerType> layers)
 	{
-		Scene* scene = SceneManager::GetActiveScene();
+		//Scene* scene = SceneManager::GetActiveScene();
+		Scene* scene = owner->GetScene();
 		ya::Ray ray = ya::Ray(position, direction);
 
 		RayHit hit = RayHit(false, nullptr, Vector3::Zero);

--- a/Engine_SOURCE/yaGameObject.cpp
+++ b/Engine_SOURCE/yaGameObject.cpp
@@ -8,6 +8,7 @@ namespace ya
 		, mType(eLayerType::None)
 		, mbDontDestroy(false)
 		, mbRender(true)
+		, mScene(nullptr)
 	{
 		mComponents.resize((UINT)eComponentType::End);
 		AddComponent(new Transform());

--- a/Engine_SOURCE/yaGameObject.h
+++ b/Engine_SOURCE/yaGameObject.h
@@ -5,6 +5,7 @@
 
 namespace ya
 {
+	class Scene;
 	class GameObject : public Entity
 	{
 		
@@ -113,6 +114,10 @@ namespace ya
 		void SetLayerType(eLayerType type) { mType = type; }
 
 		void SetRender(bool render) { mbRender = render; }
+
+		Scene* GetScene() { return mScene; }
+		void SetScene(Scene* scene) { mScene = scene; }
+
 	protected:
 		std::vector<Component*> mComponents;
 
@@ -121,7 +126,7 @@ namespace ya
 		eLayerType mType;
 		std::vector<Script*> mScripts;
 		bool mbDontDestroy;
-		//Scene* mScene;
+		Scene* mScene;
 
 		bool mbRender;
 	};

--- a/Engine_SOURCE/yaHookTargetScript.cpp
+++ b/Engine_SOURCE/yaHookTargetScript.cpp
@@ -25,7 +25,7 @@ namespace ya
 
 	void HookTargetScript::Update()
 	{
-		Scene* scene = SceneManager::GetActiveScene();
+		Scene* scene = GetOwner()->GetScene();
 		Player* player = scene->GetPlayer();
 		if (player == nullptr)
 			return;

--- a/Engine_SOURCE/yaMonsterBase.cpp
+++ b/Engine_SOURCE/yaMonsterBase.cpp
@@ -30,8 +30,6 @@ namespace ya
 	{
 		CreateMonsterState();
 
-		SetDeathBlow(true);
-
 		GameObject::Initialize();
 	}
 

--- a/Engine_SOURCE/yaObject.h
+++ b/Engine_SOURCE/yaObject.h
@@ -14,8 +14,9 @@ namespace ya::object
 		Scene* scene = SceneManager::GetActiveScene();
 		Layer& layer = scene->GetLayer(type);
 		layer.AddGameObject(gameObj);
-		gameObj->Initialize();
+		gameObj->SetScene(scene);
 		gameObj->SetLayerType(type);
+		gameObj->Initialize();
 
 		return gameObj;
 	}
@@ -26,7 +27,9 @@ namespace ya::object
 		T* gameObj = new T();
 		Layer& layer = scene->GetLayer(type);
 		layer.AddGameObject(gameObj);
+		gameObj->SetScene(scene);
 		gameObj->SetLayerType(type);
+		gameObj->Initialize();
 
 		return gameObj;
 	}

--- a/Engine_SOURCE/yaPlayer.cpp
+++ b/Engine_SOURCE/yaPlayer.cpp
@@ -39,7 +39,16 @@ namespace ya
 		mState->SetHp(mState->GetHPMax());
 		mState->SetPostureMax(100);
 		mState->SetPosture(mState->GetPostureMax());
+	}
 
+	Player::~Player()
+	{
+		delete mState;
+		mState = nullptr;
+	}
+
+	void Player::Initialize()
+	{
 		PlayerMeshScript* meshScript = AddComponent<PlayerMeshScript>();	// 메쉬, 애니메이션이므로 먼저 load
 
 		std::shared_ptr<MeshData> weaponMeshData = meshScript->FindMeshData(ARM);
@@ -57,16 +66,7 @@ namespace ya
 		AddComponent<PlayerActionScript>();
 		AddComponent<PlayerAttackScript>();
 		AddComponent<GrappleHookScript>();
-	}
 
-	Player::~Player()
-	{
-		delete mState;
-		mState = nullptr;
-	}
-
-	void Player::Initialize()
-	{
 		GameObject::Initialize();
 	}
 

--- a/Engine_SOURCE/yaSceneManager.cpp
+++ b/Engine_SOURCE/yaSceneManager.cpp
@@ -20,15 +20,13 @@ namespace ya
 	std::vector<Scene*> SceneManager::mScenes = {};
 	Scene* SceneManager::mActiveScene = nullptr;
 
-	std::vector<std::future<std::function<void()>>> futures = {};
-
 	void SceneManager::Initialize()
 	{
 		mScenes.resize((UINT)eSceneType::End);
 
 		mScenes[(UINT)eSceneType::Tilte] = new TitleScene();
 		mScenes[(UINT)eSceneType::Tilte]->SetName(L"TitleScene");
-		//mScenes[(UINT)eSceneType::Tilte]->SetThreadLoad(true);
+		mScenes[(UINT)eSceneType::Tilte]->SetThreadLoad(true);
 		mScenes[(UINT)eSceneType::Tilte]->GetCallBack() = std::bind(SceneManager::LoadScene, eSceneType::Tilte);
 
 		mScenes[(UINT)eSceneType::Play] = new PlayScene();
@@ -53,7 +51,7 @@ namespace ya
 			}
 		}
 
-		mActiveScene = mScenes[(UINT)eSceneType::Tilte];
+		mActiveScene = mScenes[(UINT)eSceneType::Loading];
 	}
 
 	void SceneManager::Update()

--- a/Engine_SOURCE/yaSpearman.cpp
+++ b/Engine_SOURCE/yaSpearman.cpp
@@ -36,7 +36,8 @@ namespace ya
 		AddComponent<Rigidbody>();
 		mActionScript = AddComponent<ActionScript>();
 
-		SetPlayerObject(SceneManager::GetActiveScene()->GetPlayer());
+		//SetPlayerObject(SceneManager::GetActiveScene()->GetPlayer());
+		SetPlayerObject(GetScene()->GetPlayer());
 
 		//BoneAnimator* animator = mMeshData->GetAnimator();
 

--- a/Engine_SOURCE/yaTenzen.cpp
+++ b/Engine_SOURCE/yaTenzen.cpp
@@ -23,8 +23,9 @@ namespace ya
 	float tenzenWalkSpeed = 71;
 	float tenzenBaseSpeed = 200;
 	Tenzen::Tenzen()
-		:mState(0)
-		,mAlertTime(10)
+		: MonsterBase()
+		, mState(0)
+		, mAlertTime(10)
 	{
 	}
 	Tenzen::~Tenzen()
@@ -109,7 +110,7 @@ namespace ya
 		mMeshData = std::make_shared<MeshData>();
 		mMeshData->Load(L"Monster\\Boss_tenzen\\Mesh\\c1020.fbx");
 		mMeshData->AnimationLoad(L"Monster\\Boss_tenzen\\AnimationData\\tenzen.animationdata");
-		MeshObject* object = mMeshData->Instantiate(eLayerType::Monster);
+		MeshObject* object = mMeshData->Instantiate(eLayerType::Monster, GetScene());
 
 
 		//칼과 손잡이 찾아두기
@@ -145,7 +146,7 @@ namespace ya
 
 		//무기 콜라이더 추가
 		//Initialize
-		BoneCollider* katana =  object::Instantiate<BoneCollider>(eLayerType::MonsterProjectile);
+		BoneCollider* katana =  object::Instantiate<BoneCollider>(eLayerType::MonsterProjectile, GetScene());
 		katana->SetMeshAndBone(mMeshData, L"R_Katana_long", this);
 		mSwordScript = katana->AddComponent<TenzenSwordScript>();
 		//애니메이션 별로 오프셋과 발동 프레임 정해주기. 
@@ -191,7 +192,8 @@ namespace ya
 
 
 
-		SetPlayerObject(dynamic_cast<Player*>(SceneManager::GetActiveScene()->GetPlayer()));
+		//SetPlayerObject(dynamic_cast<Player*>(SceneManager::GetActiveScene()->GetPlayer()));
+		SetPlayerObject(dynamic_cast<Player*>(GetScene()->GetPlayer()));
 		
 		//몬스터 스테이트
 		CreateMonsterState();

--- a/Engine_SOURCE/yaTitleScene.cpp
+++ b/Engine_SOURCE/yaTitleScene.cpp
@@ -231,7 +231,7 @@ namespace ya
 		}
 
 		{
-			GameObject* ground = object::Instantiate<GameObject>(eLayerType::Ground);
+			GameObject* ground = object::Instantiate<GameObject>(eLayerType::Ground, this);
 			ground->SetName(L"Ground2");
 			Transform* groundTr = ground->GetComponent<Transform>();
 			groundTr->SetPosition(Vector3(100.0f, -5.0f, -15.0f));
@@ -260,7 +260,7 @@ namespace ya
 
 		{
 
-			MapObjects* obj = object::Instantiate<MapObjects>(eLayerType::Player);
+			MapObjects* obj = object::Instantiate<MapObjects>(eLayerType::None, this);
 			Transform* objTransform = obj->GetComponent<Transform>();
 			objTransform->SetPosition(-85.f, 35.f, 130.f);
 			objTransform->SetRotation(-90.f, 0.f, 0.f);
@@ -269,7 +269,7 @@ namespace ya
 
 
 		{
-			GameObject* hookTarget = object::Instantiate<GameObject>(eLayerType::Ground);
+			GameObject* hookTarget = object::Instantiate<GameObject>(eLayerType::Ground, this);
 			hookTarget->SetName(L"hookTarget1");
 			Transform* groundTr = hookTarget->GetComponent<Transform>();
 			groundTr->SetPosition(Vector3(40.0f, 10.0f, -40.0f));
@@ -284,10 +284,10 @@ namespace ya
 
 
 		{
-			object::Instantiate<MapCollider>(eLayerType::Ground);
+			object::Instantiate<MapCollider>(eLayerType::Ground, this);
 		}
 		//Resources::Load<MeshData>(L"test", L"Player/Mesh/o000100.fbx");
-		object::Instantiate<Tenzen>(eLayerType::Monster);
+		object::Instantiate<Tenzen>(eLayerType::Monster, this);
 
 		Scene::Initialize();
 	}


### PR DESCRIPTION
- 스레드 사용하는 scene에서 object 생성시
object::Instantiate()로 생성할때 인자에 this(scene) 넣어주기
- GameObject는 어떤 Scene에서 생성되어 있는지 가지고있음
- 스레드 사용하는 scene에서 initialize되는 중에 생성되는 object의 경우 생성된 object의 scene을 받아와서 두번째 인자에 scene 넣어주기
- 스레드 사용하는 scene에서는 mActiveScene이 아닌 현재 object의 scene을 받아와서 사용해야함
 => 스레드 사용하는 scene에서 현재 scene을 넣어주지 않으면 오류 발생할 수 있음