### PR TITLE
player 움직임, 스케일 조정

### DIFF
--- a/44Engine/guiEditor.cpp
+++ b/44Engine/guiEditor.cpp
@@ -27,7 +27,7 @@ namespace gui
 {
 	void Editor::Initialize()
 	{
-		mEnable = false;
+		mEnable = true;
 
 		if (mEnable == false)
 			return;

--- a/Engine_SOURCE/yaActionScript.cpp
+++ b/Engine_SOURCE/yaActionScript.cpp
@@ -60,14 +60,24 @@ namespace ya
 		checkObj->SetName(L"WallCheck");
 		checkObj->SetParentObj(obj);
 
-		Collider2D* checkCol = mCheck->AddComponent<Collider2D>();
 		Transform* checkTransform = mCheck->GetComponent<Transform>();
-		
-		checkTransform->SetScale(Vector3(1.f, 1.f ,1.f));
+		checkTransform->SetScale(mTransform->GetScale());
 
-		checkCol->SetType(eColliderType::Box);
-		checkCol->SetCenter(Vector3(0.f, 1.2f, 0.f));
-		checkCol->SetSize(Vector3(1.0, 3.0f, 1.0f));
+		Collider2D* checkCol = mCheck->AddComponent<Collider2D>();
+
+		Collider2D* ownerCol = obj->GetComponent<Collider2D>();
+		if (ownerCol != nullptr)
+		{
+			checkCol->SetType(ownerCol->GetColliderType());
+			checkCol->SetCenter(ownerCol->GetCenter());
+			checkCol->SetSize(ownerCol->GetSize());
+		}
+		else
+		{
+			checkCol->SetType(eColliderType::Box);
+			checkCol->SetCenter(Vector3(0.f, 1.2f, 0.f));
+			checkCol->SetSize(Vector3(1.0, 3.0f, 1.0f));
+		}
 	}
 
 	void ActionScript::Update()

--- a/Engine_SOURCE/yaCameraScript.cpp
+++ b/Engine_SOURCE/yaCameraScript.cpp
@@ -18,7 +18,7 @@ namespace ya
 		, mChildPos(Vector3(0, 0, -40))
 		, mThetaAxisY(1.57)
 		, mThetaAxisX(1.57)
-		, mDistFromTarget(10)
+		, mDistFromTarget(3.0f)
 		, mDelayTime(0.2f)
 		, mDelayTimeChecker(0)
 		, mbFirstInit(false)

--- a/Engine_SOURCE/yaPlayer.cpp
+++ b/Engine_SOURCE/yaPlayer.cpp
@@ -20,7 +20,8 @@
 namespace ya
 {
 	Player::Player()
-		: mCamera(nullptr)
+		: GameObject()
+		, mCamera(nullptr)
 		, mProsthetic(eProsthetics::None)
 		, mWeaponCollider(nullptr)
 		, mStartStateEvent {}
@@ -28,13 +29,20 @@ namespace ya
 	{
 		SetName(L"Wolf");
 
+		Transform* tr = GetComponent<Transform>();
+		tr->SetPosition(Vector3(30.0f, 0.0f, -30.0f));
+		tr->SetScale(Vector3(0.4f, 0.4f, 0.4f));
+
+		/*MeshRenderer* mr = player->AddComponent<MeshRenderer>();
+		mr->SetMesh(Resources::Find<Mesh>(L"CubeMesh"));
+		mr->SetMaterial(Resources::Find<Material>(L"BasicMaterial"), 0);*/
+
 		Collider2D* col = AddComponent<Collider2D>();
 		col->SetType(eColliderType::Box);
 		//col->SetCenter(Vector3(0.f, 8.0f, 0.f));
 
-		col->SetCenter(Vector3(0.f, 0.85f, 0.f));
-		col->SetSize(Vector3(0.3f, 2.7f, 0.3f));
-
+		col->SetCenter(Vector3(0.f, 0.5f, 0.f));
+		col->SetSize(Vector3(0.8f, 3.4f, 0.8f));
 
 		Rigidbody* playerRigidbody = AddComponent<Rigidbody>();
 
@@ -75,13 +83,10 @@ namespace ya
 		AddComponent<PlayerAttackScript>();
 		AddComponent<GrappleHookScript>();
 
-
 		CreateHpTexture();
 
 		GameObject::Initialize();
 	}
-
-
 
 	void Player::Update()
 	{
@@ -136,24 +141,6 @@ namespace ya
 		mPlayerHpBar->SetName(L"dd");
 		mPlayerHpBar->SetPlayer(this);
 	}
-
-	//std::function<void()>& Player::GetStartStateEvent(ePlayerState state)
-	//{
-	//	std::map<ePlayerState, std::function<void()>>::iterator iter = mStartStateEvent.find(state);
-
-	//	if (iter == mStartStateEvent.end())
-	//	{
-	//		return nullptr;
-	//	}
-
-	//	return iter->second;
-	//}
-
-	//std::function<void()>& Player::GetEndStateEvent(ePlayerState state)
-	//{
-	//	// TODO: 여기에 return 문을 삽입합니다.
-	//}
-
 
 	float Player::GetBlockTime()
 	{

--- a/Engine_SOURCE/yaPlayerActionScript.cpp
+++ b/Engine_SOURCE/yaPlayerActionScript.cpp
@@ -20,14 +20,14 @@ namespace ya
 		, mbRotate(false)
 		, mLastDir(eDirection::Forward)
 		, mbDash(false)
-		, mDashSpeed(300.0f)
+		, mDashSpeed(120.0f)
 		, mDashTimer(0.0f)
 		, mDashDirection(eDirection::Forward)
 		, mHitTimer(1.0f)
 		, mbTurn(false)
 		, mTurnTimer(0.0f)
 		, mTurnTimerMax(0.4f)
-		, mFrontTheta(4.0f)
+		, mFrontTheta(5.0f)
 		, mDashTimerMax(0.2f)
 	{
 
@@ -68,7 +68,7 @@ namespace ya
 		mPlayer->GetStartStateEvent().insert(std::make_pair(ePlayerState::Sprint, [owner]() {
 			Player* player = dynamic_cast<Player*>(owner);
 			PlayerActionScript* action = player->GetScript<PlayerActionScript>();
-			action->Velocity(40.0f);
+			action->Velocity(20.0f);
 			player->SetStateFlag(ePlayerState::Walk, false);
 			}));
 
@@ -81,7 +81,7 @@ namespace ya
 		mPlayer->GetStartStateEvent().insert(std::make_pair(ePlayerState::Crouch, [owner]() {
 			Player* player = dynamic_cast<Player*>(owner);
 			PlayerActionScript* action = player->GetScript<PlayerActionScript>();
-			action->Velocity(5.0f);
+			action->Velocity(6.0f);
 			}));
 
 		mPlayer->GetEndStateEvent().insert(std::make_pair(ePlayerState::Crouch, [owner]() {
@@ -93,7 +93,7 @@ namespace ya
 		mPlayer->GetStartStateEvent().insert(std::make_pair(ePlayerState::Hang, [owner]() {
 			Player* player = dynamic_cast<Player*>(owner);
 			PlayerActionScript* action = player->GetScript<PlayerActionScript>();
-			action->Velocity(8.0f);
+			action->Velocity(6.0f);
 			}));
 
 		mPlayer->GetEndStateEvent().insert(std::make_pair(ePlayerState::Hang, [owner]() {
@@ -151,11 +151,35 @@ namespace ya
 		{
 			if (mPlayer->IsStateFlag(ePlayerState::Crouch))
 			{
-				mPlayerAnim->Play(L"a000_005000");
+				if (bLockOn)
+				{
+					if (Input::GetKey(eKeyCode::W))
+						mPlayerAnim->Play(L"a000_005100");
+					else if (Input::GetKey(eKeyCode::S))
+						mPlayerAnim->Play(L"a000_005101");
+					else if (Input::GetKey(eKeyCode::D))
+						mPlayerAnim->Play(L"a000_005103");
+					else if (Input::GetKey(eKeyCode::A))
+						mPlayerAnim->Play(L"a000_005102");
+				}
+				else
+					mPlayerAnim->Play(L"a000_005100");
 			}
 			else if (mPlayer->IsStateFlag(ePlayerState::Block))
 			{
-				mPlayerAnim->Play(L"a000_000500");
+				if (bLockOn)
+				{
+					if (Input::GetKey(eKeyCode::W))
+						mPlayerAnim->Play(L"a050_002200");
+					else if (Input::GetKey(eKeyCode::S))
+						mPlayerAnim->Play(L"a050_002201");
+					else if (Input::GetKey(eKeyCode::D))
+						mPlayerAnim->Play(L"a050_002202");
+					else if (Input::GetKey(eKeyCode::A))
+						mPlayerAnim->Play(L"a050_002203");
+				}
+				else
+					mPlayerAnim->Play(L"a050_002200");
 			}
 			else
 			{
@@ -164,19 +188,30 @@ namespace ya
 		}
 		else
 		{
-			if (bLockOn)
+			if (mPlayer->IsStateFlag(ePlayerState::Crouch))
 			{
-				if (Input::GetKey(eKeyCode::W))
-					mPlayerAnim->Play(L"a000_000500");
-				else if (Input::GetKey(eKeyCode::S))
-					mPlayerAnim->Play(L"a000_000501");
-				else if (Input::GetKey(eKeyCode::D))
-					mPlayerAnim->Play(L"a000_000502");
-				else if (Input::GetKey(eKeyCode::A))
-					mPlayerAnim->Play(L"a000_000503");
+				mPlayerAnim->Play(L"a000_005000");
+			}
+			else if (mPlayer->IsStateFlag(ePlayerState::Block))
+			{
+				mPlayerAnim->Play(L"a000_000500");
 			}
 			else
-				mPlayerAnim->Play(L"a000_000000");
+			{
+				if (bLockOn)
+				{
+					if (Input::GetKey(eKeyCode::W))
+						mPlayerAnim->Play(L"a000_000500");
+					else if (Input::GetKey(eKeyCode::S))
+						mPlayerAnim->Play(L"a000_000501");
+					else if (Input::GetKey(eKeyCode::D))
+						mPlayerAnim->Play(L"a000_000502");
+					else if (Input::GetKey(eKeyCode::A))
+						mPlayerAnim->Play(L"a000_000503");
+				}
+				else
+					mPlayerAnim->Play(L"a000_000000");
+			}
 		}
 	}
 
@@ -246,17 +281,19 @@ namespace ya
 			if (theta < mFrontTheta)
 			{	// 회전 종료. 진행하려는 방향과 player의 forward가 비슷해지면 회전이 끝난다.
 				mbRotate = false;
-				mTransform->SetRotation(Vector3(0.0f, rot.y + theta, 0.0f));
+				//mTransform->SetRotation(Vector3(0.0f, rot.y + theta, 0.0f));
+				Vector3 cameraDir = Vector3(cameraForward.x, 0.0f, cameraForward.z);
+				cameraDir.Normalize();
+				mTransform->SetForward(cameraDir);
 			}
 			else
 			{	// 진행하려는 방향과 player의 forward가 비슷해질 때 까지 회전한다. theta 각에 따라 회전 방향을 결정한다.
 				if(cross.y < 0.0f && theta > 5.0f)
-					Rotate(Vector3(0.0f, -1.0f, 0.0f));
+					Rotate(Vector3(0.0f, -(0.05f + 2.95f / 180.0f * theta), 0.0f));
 				else 	
-					Rotate(Vector3(0.0f, 1.0f, 0.0f));
+					Rotate(Vector3(0.0f, (0.05f + 2.95f / 180.0f * theta), 0.0f));
 			}
 		}
-
 
 		if (Input::GetKeyDown(eKeyCode::W))
 		{
@@ -903,11 +940,13 @@ namespace ya
 			{
 				mPlayer->SetStateFlag(ePlayerState::Crouch, false);
 				mPlayerAnim->Play(L"a000_000000");
+				AdjustState();
 			}
 			else
 			{
 				mPlayer->SetStateFlag(ePlayerState::Crouch, true);
 				mPlayerAnim->Play(L"a000_005000");
+				AdjustState();
 			}
 		}
 	}

--- a/Engine_SOURCE/yaPlayerAttackScript.cpp
+++ b/Engine_SOURCE/yaPlayerAttackScript.cpp
@@ -96,7 +96,7 @@ namespace ya
 			player->SetStateFlag(ePlayerState::Attack, false);
 			
 			PlayerActionScript* action = player->GetScript<PlayerActionScript>();
-			action->Velocity(10.0f);
+			action->Velocity(8.0f);
 		}));
 
 		mPlayer->GetEndStateEvent().insert(std::make_pair(ePlayerState::Block, [owner]() {

--- a/Engine_SOURCE/yaRenderer.cpp
+++ b/Engine_SOURCE/yaRenderer.cpp
@@ -978,7 +978,7 @@ namespace ya::renderer
 	{
 		#pragma region STATIC TEXTURE
 		Resources::Load<Texture>(L"SmileTexture", L"Smile.png");
-		Resources::Load<Texture>(L"DeathBlowTexture", L"UI\\Texture\\DeathBlow.png");
+		//Resources::Load<Texture>(L"DeathBlowTexture", L"UI\\Texture\\DeathBlow.png");
 
 		Resources::Load<Texture>(L"DefaultSprite", L"Light.png");
 		

--- a/Engine_SOURCE/yaRigidbody.cpp
+++ b/Engine_SOURCE/yaRigidbody.cpp
@@ -37,8 +37,8 @@ namespace ya
 		, mGroundEvent(nullptr)
 		, mJumpCount(0)
 	{
-		mGravity = Vector3(0.0f, -160.0f, 0.0f);
-		mLimitVelocity = Vector3(18.0f, 28.0f, 18.0f);
+		mGravity = Vector3(0.0f, -120.0f, 0.0f);
+		mLimitVelocity = Vector3(10.0f, 10.0f, 10.0f);
 	}
 
 	Rigidbody::~Rigidbody()

--- a/Engine_SOURCE/yaTitleScene.cpp
+++ b/Engine_SOURCE/yaTitleScene.cpp
@@ -71,13 +71,6 @@ namespace ya
 
 
 		Player* player = object::Instantiate<Player>(eLayerType::Player, this);
-		player->GetComponent<Transform>()->SetPosition(Vector3(30.0f, 0.0f, -30.0f));
-
-		player->GetComponent<Transform>()->SetScale(Vector3(1.0f, 1.0f, 1.0f));
-
-		/*MeshRenderer* mr = player->AddComponent<MeshRenderer>();
-		mr->SetMesh(Resources::Find<Mesh>(L"CubeMesh"));
-		mr->SetMaterial(Resources::Find<Material>(L"BasicMaterial"), 0);*/
 
 		BoundarySphere* boundarySphere = player->AddComponent<BoundarySphere>();
 


### PR DESCRIPTION
1.플레이어 회전 움직임 개선
-2.layer scale 1.0->0.4
-player scale 조절에 맞춰 속도 조정
-wallcheckobject 크기 조절
-camera 거리 변경