### PR TITLE
애니메이션 데이터 로직 수정

### DIFF
--- a/Engine_SOURCE/Engine_SOURCE.vcxproj
+++ b/Engine_SOURCE/Engine_SOURCE.vcxproj
@@ -195,6 +195,7 @@ call CopyDLL.bat $(Configuration)</Command>
     <ClInclude Include="UIHPBarScript.h" />
     <ClInclude Include="UINames.h" />
     <ClInclude Include="Utils.h" />
+    <ClInclude Include="yaAnimationData.h" />
     <ClInclude Include="yaAshinaSoldier.h" />
     <ClInclude Include="yaBoundarySphere.h" />
     <ClInclude Include="yaFrustum.h" />
@@ -332,6 +333,7 @@ call CopyDLL.bat $(Configuration)</Command>
     <ClCompile Include="UICanvas_InGame.cpp" />
     <ClCompile Include="UIHPBarScript.cpp" />
     <ClCompile Include="Utils.cpp" />
+    <ClCompile Include="yaAnimationData.cpp" />
     <ClCompile Include="yaAshinaSoldier.cpp" />
     <ClCompile Include="yaBoundarySphere.cpp" />
     <ClCompile Include="yaFrustum.cpp" />

--- a/Engine_SOURCE/Engine_SOURCE.vcxproj
+++ b/Engine_SOURCE/Engine_SOURCE.vcxproj
@@ -195,6 +195,7 @@ call CopyDLL.bat $(Configuration)</Command>
     <ClInclude Include="UIHPBarScript.h" />
     <ClInclude Include="UINames.h" />
     <ClInclude Include="Utils.h" />
+    <ClInclude Include="yaAshinaSoldier.h" />
     <ClInclude Include="yaBoundarySphere.h" />
     <ClInclude Include="yaFrustum.h" />
     <ClInclude Include="yaHPMeterScript.h" />
@@ -268,6 +269,7 @@ call CopyDLL.bat $(Configuration)</Command>
     <ClInclude Include="yaPlayerActionScript.h" />
     <ClInclude Include="yaPlayerProjectileScript.h" />
     <ClInclude Include="StrConverter.h" />
+    <ClInclude Include="yaSoldierSwordScript.h" />
     <ClInclude Include="yaSwordManSwordScript.h" />
     <ClInclude Include="yaTitleScene.h" />
     <ClInclude Include="yaPrefab.h" />
@@ -330,6 +332,7 @@ call CopyDLL.bat $(Configuration)</Command>
     <ClCompile Include="UICanvas_InGame.cpp" />
     <ClCompile Include="UIHPBarScript.cpp" />
     <ClCompile Include="Utils.cpp" />
+    <ClCompile Include="yaAshinaSoldier.cpp" />
     <ClCompile Include="yaBoundarySphere.cpp" />
     <ClCompile Include="yaFrustum.cpp" />
     <ClCompile Include="yaHPMeterScript.cpp" />
@@ -399,6 +402,7 @@ call CopyDLL.bat $(Configuration)</Command>
     <ClCompile Include="yaPlayerActionScript.cpp" />
     <ClCompile Include="yaPlayerProjectileScript.cpp" />
     <ClCompile Include="StrConverter.cpp" />
+    <ClCompile Include="yaSoldierSwordScript.cpp" />
     <ClCompile Include="yaSwordManSwordScript.cpp" />
     <ClCompile Include="yaTitleScene.cpp" />
     <ClCompile Include="yaPrefab.cpp" />

--- a/Engine_SOURCE/Engine_SOURCE.vcxproj.filters
+++ b/Engine_SOURCE/Engine_SOURCE.vcxproj.filters
@@ -380,6 +380,12 @@
     <ClCompile Include="yaSwordManSwordScript.cpp">
       <Filter>Contents\Monster\SwordMan</Filter>
     </ClCompile>
+    <ClCompile Include="yaAshinaSoldier.cpp">
+      <Filter>Contents\Monster\AshinaSoldier</Filter>
+    </ClCompile>
+    <ClCompile Include="yaSoldierSwordScript.cpp">
+      <Filter>Contents\Monster\AshinaSoldier</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="yaMath.h">
@@ -766,6 +772,12 @@
     <ClInclude Include="yaMonsterCollisionScript.h">
       <Filter>Contents\Monster</Filter>
     </ClInclude>
+    <ClInclude Include="yaAshinaSoldier.h">
+      <Filter>Contents\Monster\AshinaSoldier</Filter>
+    </ClInclude>
+    <ClInclude Include="yaSoldierSwordScript.h">
+      <Filter>Contents\Monster\AshinaSoldier</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Engine">
@@ -977,6 +989,9 @@
     </Filter>
     <Filter Include="Contents\Monster\SwordMan">
       <UniqueIdentifier>{afcd2e4b-ab7d-4f73-89d8-1c28d841c4d9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Contents\Monster\AshinaSoldier">
+      <UniqueIdentifier>{60eb5981-72f1-4d65-bbeb-32cc16935806}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Engine_SOURCE/Engine_SOURCE.vcxproj.filters
+++ b/Engine_SOURCE/Engine_SOURCE.vcxproj.filters
@@ -386,6 +386,9 @@
     <ClCompile Include="yaSoldierSwordScript.cpp">
       <Filter>Contents\Monster\AshinaSoldier</Filter>
     </ClCompile>
+    <ClCompile Include="yaAnimationData.cpp">
+      <Filter>Engine\Resource\MeshData</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="yaMath.h">
@@ -777,6 +780,9 @@
     </ClInclude>
     <ClInclude Include="yaSoldierSwordScript.h">
       <Filter>Contents\Monster\AshinaSoldier</Filter>
+    </ClInclude>
+    <ClInclude Include="yaAnimationData.h">
+      <Filter>Engine\Resource\MeshData</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Engine_SOURCE/yaAnimationData.cpp
+++ b/Engine_SOURCE/yaAnimationData.cpp
@@ -1,0 +1,288 @@
+#include "yaAnimationData.h"
+#include "yaGameObject.h"
+#include "yaFbxLoader.h"
+#include "yaResources.h"
+#include "yaObject.h"
+#include "yaMeshRenderer.h"
+#include "yaMeshObject.h"
+#include "yaBoneAnimator.h"
+#include "Utils.h"
+#include "CommonInclude.h"
+#include "yaBoundarySphere.h"
+#include "yaScene.h"
+#include "StrConverter.h"
+
+using namespace std;
+namespace ya
+{
+	AnimationData::AnimationData()
+		: Resource(eResourceType::AnimationData)
+		, mAnimationClipCount(0)
+		, mIFrameCount(0)
+	{
+	}
+
+	AnimationData::~AnimationData()
+	{
+		for (size_t i = 0; i < mBoneFrameDataVector.size(); i++)
+		{
+			delete mBoneFrameDataVector[i];
+		}
+
+	}
+	HRESULT AnimationData::Save(const std::wstring& path, FILE* file)
+	{
+		return S_OK;
+	}
+	HRESULT AnimationData::Load(const std::wstring& path, FILE* file)
+	{
+
+		return S_OK;
+	}
+	HRESULT AnimationData::LoadNotFin(const std::wstring& path, FILE* file)
+	{
+		std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
+
+		std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
+
+		std::filesystem::path parentPath = strPath;
+		parentPath = parentPath.parent_path().parent_path();
+		parentPath += L"\\AnimationData\\";
+
+		CurparentPath /= parentPath;
+
+		std::wstring name = std::filesystem::path(path).stem();
+		name += L".animationdata";
+
+		CurparentPath += name;
+
+		std::wstring fullPath = CurparentPath;
+
+		file = nullptr;
+		_wfopen_s(&file, fullPath.c_str(), L"rb");
+		if (file == nullptr)
+			return S_FALSE;
+
+		//본 사이즈 
+		UINT boneSize = 0;
+		fread(&boneSize, sizeof(UINT), 1, file);
+
+
+		//애니 클립 사이즈 저장
+		UINT AnimClipSize = 0;
+		fread(&AnimClipSize, sizeof(UINT), 1, file);
+		mAnimationClipCount += AnimClipSize;
+
+		std::vector<BoneAnimationClip> animClip;
+
+		animClip.resize(AnimClipSize);
+		for (size_t i = 0; i < AnimClipSize; i++)
+		{
+			LoadWString(animClip[i].name, file);
+
+			fread(&animClip[i].startTime, sizeof(double), 1, file);
+			fread(&animClip[i].endTime, sizeof(double), 1, file);
+			fread(&animClip[i].timeLength, sizeof(double), 1, file);
+			fread(&animClip[i].mode, sizeof(int), 1, file);
+			fread(&animClip[i].updateTime, sizeof(float), 1, file);
+			fread(&animClip[i].startFrame, sizeof(int), 1, file);
+			fread(&animClip[i].endFrame, sizeof(int), 1, file);
+			fread(&animClip[i].frameLength, sizeof(int), 1, file);
+		}
+
+		// 본정보들 전부 저장	
+		//UINT iFrameCount = 0;
+		mBones.resize(boneSize);
+		for (size_t i = 0; i < boneSize; i++)
+		{
+			LoadWString(mBones[i].name, file);
+			fread(&mBones[i].depth, sizeof(int), 1, file);
+			fread(&mBones[i].parentIdx, sizeof(int), 1, file);
+			fread(&mBones[i].bone, sizeof(Matrix), 1, file);
+			fread(&mBones[i].offset, sizeof(Matrix), 1, file);
+
+			std::vector<std::vector<BoneKeyFrame>> keyFrames;
+			keyFrames.resize(AnimClipSize);
+			//mBones[i].keyFrames.resize(AnimClipSize);
+			for (size_t j = 0; j < AnimClipSize; j++)
+			{
+				UINT boneKeyFramesSize;
+				fread(&boneKeyFramesSize, sizeof(UINT), 1, file);
+
+				keyFrames[j].resize(boneKeyFramesSize);
+
+				for (UINT k = 0; k < keyFrames[j].size(); k++)
+				{
+					fread(&keyFrames[j][k].time, sizeof(double), 1, file);
+					fread(&keyFrames[j][k].frame, sizeof(int), 1, file);
+					fread(&keyFrames[j][k].translate, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].scale, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
+				}
+				mIFrameCount = max(mIFrameCount, (UINT)keyFrames[j].size());
+
+				/*
+				mBones[i].keyFrames[j].resize(boneKeyFramesSize);
+				for (UINT k = 0; k < mBones[i].keyFrames[j].size(); k++)
+				{
+					fread(&mBones[i].keyFrames[j][k].time, sizeof(double), 1, file);
+					fread(&mBones[i].keyFrames[j][k].frame, sizeof(int), 1, file);
+					fread(&mBones[i].keyFrames[j][k].translate, sizeof(Vector3), 1, file);
+					fread(&mBones[i].keyFrames[j][k].scale, sizeof(Vector3), 1, file);
+					fread(&mBones[i].keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
+				}
+				iFrameCount = max(iFrameCount, (UINT)mBones[i].keyFrames[j].size());
+				*/
+			}
+			mBones[i].keyFrames.insert(mBones[i].keyFrames.end(), keyFrames.begin(), keyFrames.end());
+		}
+
+		fclose(file);
+
+		mAnimClip.insert(mAnimClip.end(), animClip.begin(), animClip.end());
+
+		return S_OK;
+	}
+	std::shared_ptr<AnimationData> AnimationData::LoadFin(const std::wstring& path, FILE* file)
+	{
+		std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
+
+		std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
+
+		std::filesystem::path parentPath = strPath;
+		parentPath = parentPath.parent_path().parent_path();
+		parentPath += L"\\AnimationData\\";
+
+		CurparentPath /= parentPath;
+
+		std::wstring name = std::filesystem::path(path).stem();
+		name += L".animationdata";
+
+		CurparentPath += name;
+
+		std::wstring fullPath = CurparentPath;
+		std::wstring key = fullPath;
+
+		file = nullptr;
+		_wfopen_s(&file, fullPath.c_str(), L"rb");
+		if (file == nullptr)
+			assert(NULL);
+
+		//본 사이즈 
+		UINT boneSize = 0;
+		fread(&boneSize, sizeof(UINT), 1, file);
+
+
+		//애니 클립 사이즈 저장
+		UINT AnimClipSize = 0;
+		fread(&AnimClipSize, sizeof(UINT), 1, file);
+		mAnimationClipCount += AnimClipSize;
+
+		std::vector<BoneAnimationClip> animClip;
+
+		animClip.resize(AnimClipSize);
+		for (size_t i = 0; i < AnimClipSize; i++)
+		{
+			LoadWString(animClip[i].name, file);
+
+			fread(&animClip[i].startTime, sizeof(double), 1, file);
+			fread(&animClip[i].endTime, sizeof(double), 1, file);
+			fread(&animClip[i].timeLength, sizeof(double), 1, file);
+			fread(&animClip[i].mode, sizeof(int), 1, file);
+			fread(&animClip[i].updateTime, sizeof(float), 1, file);
+			fread(&animClip[i].startFrame, sizeof(int), 1, file);
+			fread(&animClip[i].endFrame, sizeof(int), 1, file);
+			fread(&animClip[i].frameLength, sizeof(int), 1, file);
+		}
+
+		// 본정보들 전부 저장	
+		//UINT iFrameCount = 0;
+		mBones.resize(boneSize);
+		for (size_t i = 0; i < boneSize; i++)
+		{
+			LoadWString(mBones[i].name, file);
+			fread(&mBones[i].depth, sizeof(int), 1, file);
+			fread(&mBones[i].parentIdx, sizeof(int), 1, file);
+			fread(&mBones[i].bone, sizeof(Matrix), 1, file);
+			fread(&mBones[i].offset, sizeof(Matrix), 1, file);
+
+			std::vector<std::vector<BoneKeyFrame>> keyFrames;
+			keyFrames.resize(AnimClipSize);
+			//mBones[i].keyFrames.resize(AnimClipSize);
+			for (size_t j = 0; j < AnimClipSize; j++)
+			{
+				UINT boneKeyFramesSize;
+				fread(&boneKeyFramesSize, sizeof(UINT), 1, file);
+
+				keyFrames[j].resize(boneKeyFramesSize);
+
+				for (UINT k = 0; k < keyFrames[j].size(); k++)
+				{
+					fread(&keyFrames[j][k].time, sizeof(double), 1, file);
+					fread(&keyFrames[j][k].frame, sizeof(int), 1, file);
+					fread(&keyFrames[j][k].translate, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].scale, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
+				}
+				mIFrameCount = max(mIFrameCount, (UINT)keyFrames[j].size());
+
+			}
+			mBones[i].keyFrames.insert(mBones[i].keyFrames.end(), keyFrames.begin(), keyFrames.end());
+		}
+
+		fclose(file);
+
+		mAnimClip.insert(mAnimClip.end(), animClip.begin(), animClip.end());
+
+		{
+			std::vector<std::vector<BoneFrameTransform>> vecFrameTrans;
+			vecFrameTrans.resize(mAnimationClipCount);
+
+			for (size_t i = 0; i < mBones.size(); ++i)
+			{
+				for (size_t k = 0; k < mAnimationClipCount; k++)
+				{
+					vecFrameTrans[k].resize((UINT)mBones.size() * mIFrameCount);
+					for (size_t j = 0; j < mBones[i].keyFrames[k].size(); ++j)
+					{
+						vecFrameTrans[k][(UINT)mBones.size() * j + i]
+							= BoneFrameTransform
+						{
+							Vector4(mBones[i].keyFrames[k][j].translate.x 
+							, mBones[i].keyFrames[k][j].translate.y  
+								, mBones[i].keyFrames[k][j].translate.z  , 0.f)
+							, Vector4(mBones[i].keyFrames[k][j].scale.x
+								, mBones[i].keyFrames[k][j].scale.y
+								, mBones[i].keyFrames[k][j].scale.z, 0.f)
+							, mBones[i].keyFrames[k][j].rotation
+						};
+					}
+				}
+			}
+
+			for (size_t i = 0; i < mAnimationClipCount; i++)
+			{
+				graphics::StructedBuffer* boneFrameData = new graphics::StructedBuffer();
+				boneFrameData->Create(sizeof(BoneFrameTransform), (UINT)mBones.size() * mIFrameCount
+					, eSRVType::SRV, vecFrameTrans[i].data(), false);
+				PushBackBoneFrameData(boneFrameData);
+			}
+		}
+
+		std::shared_ptr<AnimationData> resourcePtr(this);
+
+		Resources::Insert<AnimationData>(fullPath, resourcePtr);
+
+		return resourcePtr;
+
+	}
+	void AnimationData::LoadWString(std::wstring& _str, FILE* _pFile)
+	{
+		size_t iLen = 0;
+		fread(&iLen, sizeof(size_t), 1, _pFile);
+
+		wchar_t szBuff[256] = {};
+		fread(szBuff, sizeof(wchar_t), iLen, _pFile);
+		_str = szBuff;
+	}
+}

--- a/Engine_SOURCE/yaAnimationData.cpp
+++ b/Engine_SOURCE/yaAnimationData.cpp
@@ -1,0 +1,287 @@
+#include "yaAnimationData.h"
+#include "yaGameObject.h"
+#include "yaFbxLoader.h"
+#include "yaResources.h"
+#include "yaObject.h"
+#include "yaMeshRenderer.h"
+#include "yaMeshObject.h"
+#include "yaBoneAnimator.h"
+#include "Utils.h"
+#include "CommonInclude.h"
+#include "yaBoundarySphere.h"
+#include "yaScene.h"
+#include "StrConverter.h"
+
+using namespace std;
+namespace ya
+{
+	AnimationData::AnimationData()
+		: Resource(eResourceType::AnimationData)
+		, mAnimationClipCount(0)
+		, mIFrameCount(0)
+	{
+
+	}
+
+	AnimationData::~AnimationData()
+	{
+		for (size_t i = 0; i < mBoneFrameDataVector.size(); i++)
+		{
+			delete mBoneFrameDataVector[i];
+		}
+
+	}
+	HRESULT AnimationData::Save(const std::wstring& path, FILE* file)
+	{
+		return S_OK;
+	}
+	HRESULT AnimationData::Load(const std::wstring& path, FILE* file)
+	{
+
+		return S_OK;
+	}
+	HRESULT AnimationData::LoadNotFin(const std::wstring& path, FILE* file)
+	{
+		std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
+
+		std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
+
+		std::filesystem::path parentPath = strPath;
+		parentPath = parentPath.parent_path().parent_path();
+		parentPath += L"\\AnimationData\\";
+
+		CurparentPath /= parentPath;
+
+		std::wstring name = std::filesystem::path(path).stem();
+		name += L".animationdata";
+
+		CurparentPath += name;
+
+		std::wstring fullPath = CurparentPath;
+
+		file = nullptr;
+		_wfopen_s(&file, fullPath.c_str(), L"rb");
+		if (file == nullptr)
+			return S_FALSE;
+
+		//본 사이즈 
+		UINT boneSize = 0;
+		fread(&boneSize, sizeof(UINT), 1, file);
+
+
+		//애니 클립 사이즈 저장
+		UINT AnimClipSize = 0;
+		fread(&AnimClipSize, sizeof(UINT), 1, file);
+		mAnimationClipCount += AnimClipSize;
+
+		std::vector<BoneAnimationClip> animClip;
+
+		animClip.resize(AnimClipSize);
+		for (size_t i = 0; i < AnimClipSize; i++)
+		{
+			LoadWString(animClip[i].name, file);
+
+			fread(&animClip[i].startTime, sizeof(double), 1, file);
+			fread(&animClip[i].endTime, sizeof(double), 1, file);
+			fread(&animClip[i].timeLength, sizeof(double), 1, file);
+			fread(&animClip[i].mode, sizeof(int), 1, file);
+			fread(&animClip[i].updateTime, sizeof(float), 1, file);
+			fread(&animClip[i].startFrame, sizeof(int), 1, file);
+			fread(&animClip[i].endFrame, sizeof(int), 1, file);
+			fread(&animClip[i].frameLength, sizeof(int), 1, file);
+		}
+
+		// 본정보들 전부 저장	
+		//UINT iFrameCount = 0;
+		mBones.resize(boneSize);
+		for (size_t i = 0; i < boneSize; i++)
+		{
+			LoadWString(mBones[i].name, file);
+			fread(&mBones[i].depth, sizeof(int), 1, file);
+			fread(&mBones[i].parentIdx, sizeof(int), 1, file);
+			fread(&mBones[i].bone, sizeof(Matrix), 1, file);
+			fread(&mBones[i].offset, sizeof(Matrix), 1, file);
+
+			std::vector<std::vector<BoneKeyFrame>> keyFrames;
+			keyFrames.resize(AnimClipSize);
+			//mBones[i].keyFrames.resize(AnimClipSize);
+			for (size_t j = 0; j < AnimClipSize; j++)
+			{
+				UINT boneKeyFramesSize;
+				fread(&boneKeyFramesSize, sizeof(UINT), 1, file);
+
+				keyFrames[j].resize(boneKeyFramesSize);
+
+				for (UINT k = 0; k < keyFrames[j].size(); k++)
+				{
+					fread(&keyFrames[j][k].time, sizeof(double), 1, file);
+					fread(&keyFrames[j][k].frame, sizeof(int), 1, file);
+					fread(&keyFrames[j][k].translate, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].scale, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
+				}
+				mIFrameCount = max(mIFrameCount, (UINT)keyFrames[j].size());
+
+				/*
+				mBones[i].keyFrames[j].resize(boneKeyFramesSize);
+				for (UINT k = 0; k < mBones[i].keyFrames[j].size(); k++)
+				{
+					fread(&mBones[i].keyFrames[j][k].time, sizeof(double), 1, file);
+					fread(&mBones[i].keyFrames[j][k].frame, sizeof(int), 1, file);
+					fread(&mBones[i].keyFrames[j][k].translate, sizeof(Vector3), 1, file);
+					fread(&mBones[i].keyFrames[j][k].scale, sizeof(Vector3), 1, file);
+					fread(&mBones[i].keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
+				}
+				iFrameCount = max(iFrameCount, (UINT)mBones[i].keyFrames[j].size());
+				*/
+			}
+			mBones[i].keyFrames.insert(mBones[i].keyFrames.end(), keyFrames.begin(), keyFrames.end());
+		}
+
+		fclose(file);
+
+		mAnimClip.insert(mAnimClip.end(), animClip.begin(), animClip.end());
+
+		return S_OK;
+	}
+	std::shared_ptr<AnimationData> AnimationData::LoadFin(const std::wstring& path, FILE* file)
+	{
+		std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
+
+		std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
+
+		std::filesystem::path parentPath = strPath;
+		parentPath = parentPath.parent_path().parent_path();
+		parentPath += L"\\AnimationData\\";
+
+		CurparentPath /= parentPath;
+
+		std::wstring name = std::filesystem::path(path).stem();
+		name += L".animationdata";
+
+		CurparentPath += name;
+
+		std::wstring fullPath = CurparentPath;
+		std::wstring key = fullPath;
+
+		file = nullptr;
+		_wfopen_s(&file, fullPath.c_str(), L"rb");
+		if (file == nullptr)
+			assert(NULL);
+
+		//본 사이즈 
+		UINT boneSize = 0;
+		fread(&boneSize, sizeof(UINT), 1, file);
+
+
+		//애니 클립 사이즈 저장
+		UINT AnimClipSize = 0;
+		fread(&AnimClipSize, sizeof(UINT), 1, file);
+		mAnimationClipCount += AnimClipSize;
+
+		std::vector<BoneAnimationClip> animClip;
+
+		animClip.resize(AnimClipSize);
+		for (size_t i = 0; i < AnimClipSize; i++)
+		{
+			LoadWString(animClip[i].name, file);
+
+			fread(&animClip[i].startTime, sizeof(double), 1, file);
+			fread(&animClip[i].endTime, sizeof(double), 1, file);
+			fread(&animClip[i].timeLength, sizeof(double), 1, file);
+			fread(&animClip[i].mode, sizeof(int), 1, file);
+			fread(&animClip[i].updateTime, sizeof(float), 1, file);
+			fread(&animClip[i].startFrame, sizeof(int), 1, file);
+			fread(&animClip[i].endFrame, sizeof(int), 1, file);
+			fread(&animClip[i].frameLength, sizeof(int), 1, file);
+		}
+
+		// 본정보들 전부 저장	
+		//UINT iFrameCount = 0;
+		mBones.resize(boneSize);
+		for (size_t i = 0; i < boneSize; i++)
+		{
+			LoadWString(mBones[i].name, file);
+			fread(&mBones[i].depth, sizeof(int), 1, file);
+			fread(&mBones[i].parentIdx, sizeof(int), 1, file);
+			fread(&mBones[i].bone, sizeof(Matrix), 1, file);
+			fread(&mBones[i].offset, sizeof(Matrix), 1, file);
+
+			std::vector<std::vector<BoneKeyFrame>> keyFrames;
+			keyFrames.resize(AnimClipSize);
+			//mBones[i].keyFrames.resize(AnimClipSize);
+			for (size_t j = 0; j < AnimClipSize; j++)
+			{
+				UINT boneKeyFramesSize;
+				fread(&boneKeyFramesSize, sizeof(UINT), 1, file);
+
+				keyFrames[j].resize(boneKeyFramesSize);
+
+				for (UINT k = 0; k < keyFrames[j].size(); k++)
+				{
+					fread(&keyFrames[j][k].time, sizeof(double), 1, file);
+					fread(&keyFrames[j][k].frame, sizeof(int), 1, file);
+					fread(&keyFrames[j][k].translate, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].scale, sizeof(Vector3), 1, file);
+					fread(&keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
+				}
+				mIFrameCount = max(mIFrameCount, (UINT)keyFrames[j].size());
+
+			}
+			mBones[i].keyFrames.insert(mBones[i].keyFrames.end(), keyFrames.begin(), keyFrames.end());
+		}
+
+		fclose(file);
+
+		mAnimClip.insert(mAnimClip.end(), animClip.begin(), animClip.end());
+
+		{
+			std::vector<std::vector<BoneFrameTransform>> vecFrameTrans;
+			vecFrameTrans.resize(mAnimationClipCount);
+
+			for (size_t i = 0; i < mBones.size(); ++i)
+			{
+				for (size_t k = 0; k < mAnimationClipCount; k++)
+				{
+					vecFrameTrans[k].resize((UINT)mBones.size() * mIFrameCount);
+					for (size_t j = 0; j < mBones[i].keyFrames[k].size(); ++j)
+					{
+						vecFrameTrans[k][(UINT)mBones.size() * j + i]
+							= BoneFrameTransform
+						{
+							Vector4(mBones[i].keyFrames[k][j].translate.x 
+							, mBones[i].keyFrames[k][j].translate.y  
+								, mBones[i].keyFrames[k][j].translate.z  , 0.f)
+							, Vector4(mBones[i].keyFrames[k][j].scale.x
+								, mBones[i].keyFrames[k][j].scale.y
+								, mBones[i].keyFrames[k][j].scale.z, 0.f)
+							, mBones[i].keyFrames[k][j].rotation
+						};
+					}
+				}
+			}
+
+			for (size_t i = 0; i < mAnimationClipCount; i++)
+			{
+				graphics::StructedBuffer* boneFrameData = new graphics::StructedBuffer();
+				boneFrameData->Create(sizeof(BoneFrameTransform), (UINT)mBones.size() * mIFrameCount
+					, eSRVType::SRV, vecFrameTrans[i].data(), false);
+				PushBackBoneFrameData(boneFrameData);
+			}
+		}
+
+
+
+		return nullptr;
+
+	}
+	void AnimationData::LoadWString(std::wstring& _str, FILE* _pFile)
+	{
+		size_t iLen = 0;
+		fread(&iLen, sizeof(size_t), 1, _pFile);
+
+		wchar_t szBuff[256] = {};
+		fread(szBuff, sizeof(wchar_t), iLen, _pFile);
+		_str = szBuff;
+	}
+}

--- a/Engine_SOURCE/yaAnimationData.h
+++ b/Engine_SOURCE/yaAnimationData.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "yaResource.h"
+#include "yaMeshData.h"
+
+
+namespace ya
+{
+	class Scene;
+	class AnimationData : public Resource
+	{
+	public:
+
+		AnimationData();
+		virtual ~AnimationData();
+		virtual HRESULT Save(const std::wstring& path, FILE* file = nullptr) override;
+		virtual HRESULT Load(const std::wstring& path, FILE* file = nullptr) override;
+
+		virtual HRESULT LoadNotFin(const std::wstring& path, FILE* file = nullptr) ;
+		virtual std::shared_ptr<AnimationData> LoadFin(const std::wstring& path, FILE* file = nullptr) ;
+
+		void LoadWString(std::wstring& _str, FILE* _pFile);
+		void PushBackBoneFrameData(graphics::StructedBuffer* buffer) { mBoneFrameDataVector.push_back(buffer); }
+
+		std::vector<graphics::StructedBuffer*> GetBoneFrameDataVector() { return mBoneFrameDataVector; }
+		UINT GetAnimationClipCount() { return mAnimationClipCount; }
+		std::vector<BoneMatrix>* GetBones() { return &mBones; }
+		std::vector<BoneAnimationClip>* GetAnimClips() { return &mAnimClip; }
+
+	private:
+		std::vector<BoneAnimationClip> mAnimClip;
+		std::vector<BoneMatrix> mBones;
+		std::vector<graphics::StructedBuffer*> mBoneFrameDataVector; // 전체 본 프레임 정보 ( 크기, 이름, 회전) 프레임 갯수만큼
+		UINT mAnimationClipCount;
+		UINT mIFrameCount;
+
+	};
+}
+

--- a/Engine_SOURCE/yaAnimationData.h
+++ b/Engine_SOURCE/yaAnimationData.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "yaResource.h"
+#include "yaMeshData.h"
+
+
+namespace ya
+{
+	class Scene;
+	class AnimationData : public Resource
+	{
+	public:
+
+		AnimationData();
+		virtual ~AnimationData();
+		virtual HRESULT Save(const std::wstring& path, FILE* file = nullptr) override;
+		virtual HRESULT Load(const std::wstring& path, FILE* file = nullptr) override;
+
+		virtual HRESULT LoadNotFin(const std::wstring& path, FILE* file = nullptr) ;
+		virtual std::shared_ptr<AnimationData> LoadFin(const std::wstring& path, FILE* file = nullptr) ;
+
+		void LoadWString(std::wstring& _str, FILE* _pFile);
+		void PushBackBoneFrameData(graphics::StructedBuffer* buffer) { mBoneFrameDataVector.push_back(buffer); }
+
+		std::vector<graphics::StructedBuffer*> GetBoneFrameDataVector() { return mBoneFrameDataVector; }
+		UINT GetAnimationClipCount() { return mAnimationClipCount; }
+		std::vector<BoneMatrix>* GetBones() { return &mBones; }
+		std::vector<BoneAnimationClip>* GetAnimClips() { return &mAnimClip; }
+
+	private:
+		std::vector<BoneAnimationClip> mAnimClip;
+		std::vector<BoneMatrix> mBones;
+		std::vector<graphics::StructedBuffer*> mBoneFrameDataVector; // 전체 본 프레임 정보 ( 크기, 이름, 회전) 프레임 갯수만큼
+		UINT mAnimationClipCount;
+		UINT mIFrameCount;
+	};
+}
+

--- a/Engine_SOURCE/yaAshinaSoldier.cpp
+++ b/Engine_SOURCE/yaAshinaSoldier.cpp
@@ -1,0 +1,40 @@
+#include "yaAshinaSoldier.h"
+
+namespace ya
+{
+	AshinaSoldier::AshinaSoldier()
+	{
+	}
+	AshinaSoldier::~AshinaSoldier()
+	{
+	}
+	void AshinaSoldier::Initialize()
+	{
+		SetName(L"SwordManObject");
+
+		////fbx 로드
+		mMeshData = MeshData::LoadFromFbx(L"Monster\\AshinaSoldier\\Mesh\\c1010.fbx");
+		MeshObject* object = mMeshData->Instantiate(eLayerType::Monster, GetScene());
+	}
+	void AshinaSoldier::Update()
+	{
+	}
+	void AshinaSoldier::FixedUpdate()
+	{
+	}
+	void AshinaSoldier::Render()
+	{
+	}
+	void AshinaSoldier::DeathBlow()
+	{
+	}
+	void AshinaSoldier::OnCollisionEnter(Collider2D* collider)
+	{
+	}
+	void AshinaSoldier::OnCollisionStay(Collider2D* collider)
+	{
+	}
+	void AshinaSoldier::OnCollisionExit(Collider2D* collider)
+	{
+	}
+}

--- a/Engine_SOURCE/yaAshinaSoldier.cpp
+++ b/Engine_SOURCE/yaAshinaSoldier.cpp
@@ -12,9 +12,76 @@ namespace ya
 	{
 		SetName(L"SwordManObject");
 
+		//mMeshData = MeshData::LoadFromFbx(L"Monster\\Boss_tenzen\\Mesh\\c1020.fbx");
+		//
+		//
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_000600.fbx", L"LookAround");
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_001040.fbx", L"DrawSword");
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003000.fbx", L"SwordAttack_1"); // 칼을 우상단에서 우하단으로 크게 휘두르고 제자리로.
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003001.fbx", L"SwordAttack_2"); // 칼을 좌하단에서 우상단으로. 한걸음 내딛으며.
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003003.fbx", L"SwordAttack_3"); // 전진 점프 하며, 칼을 우상단에서 좌하단으로. 한걸음 내딛으며.
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003004.fbx", L"SwordAttack_4"); // 못막는 공격, 하단 베기
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003005.fbx", L"SwordAttack_5"); // 못막는 공격, 찌르기. 전진
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003006.fbx", L"SwordAttack_6"); // 양옆으로 휘두르기, 2회 연속공격, 2회전진
+		// 
+		//
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003051.fbx", L"SwordAttack_7"); // 좌상 - 우하 빠른 공격
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003054.fbx", L"SwordAttack_8"); // 트리플공격
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003056.fbx", L"SwordAttack_9"); // 우상 - 좌하 빠른 공격
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003020.fbx", L"EnergyRestore"); // 에너지 채우기 ?
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003067.fbx", L"Kick"); // 발로 차기
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003008.fbx", L"HandleAttack"); // 칼 손잡이로 치기
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003009.fbx", L"SwordAttack_10"); // 손잡이 연계기
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003012.fbx", L"Catch"); // 잡기
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_004100.fbx", L"PoundIntoGround"); // 잡기 연계기 바닥에 꽂기
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003014.fbx", L"ChageForm"); // 자세 바꾸기
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_003015.fbx", L"ChargeAttack"); // 자세 바꾼상태에서 거리주면 연계기
+		// 
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_005000.fbx", L"WalkNoSword");
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008010.fbx", L"Hit1"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008011.fbx", L"Hit2"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008300.fbx", L"GrogyDownFront"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008301.fbx", L"GrogyDownBack"); 
+		//  
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008400.fbx", L"GuardLeft"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008401.fbx", L"GuardRight"); 
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008600.fbx", L"ParriedLeft"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008601.fbx", L"ParriedRight"); 
+		// 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008700.fbx", L"BlockedLeft"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_008701.fbx", L"BlockedRight"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_012000.fbx", L"DeathBlow1"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_012001.fbx", L"DeathBlow1_Death"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_012200.fbx", L"DeathBlowBackside"); 
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_405000.fbx", L"WalkWithSword");
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_405010.fbx", L"RunWithSword");
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\Boss_tenzen\\Animation\\a000_500000.fbx", L"Defense");
+		//mMeshData->AnimationSave(L"Monster\\Boss_tenzen\\AnimationData\\tenzen.animationdata");
+
+
+
 		////fbx 로드
-		mMeshData = MeshData::LoadFromFbx(L"Monster\\AshinaSoldier\\Mesh\\c1010.fbx");
+		////mMeshData = MeshData::LoadFromFbx(L"Monster\\AshinaSoldier\\Mesh\\c1010.fbx");
+		//mMeshData->LoadAnimationFromFbx(L"Monster\\AshinaSoldier\\Animation\\a000_000000.fbx", L"Idle");
+		//mMeshData->AnimationSave(L"Monster\\AshinaSoldier\\AnimationData\\tenzen.animationdata");
+		
+
+		mMeshData = std::make_shared<MeshData>();
+		mMeshData->Load(L"Monster\\AshinaSoldier\\Mesh\\c1010.fbx");
+		mMeshData->AnimationLoad(L"Monster\\AshinaSoldier\\AnimationData\\tenzen.animationdata");
 		MeshObject* object = mMeshData->Instantiate(eLayerType::Monster, GetScene());
+
+		//동일 애니메이션 반복시 보간을 하지 않고 싶은 경우. (기본은 보간을 하도록 되어있음.)
+		BoneAnimator* animator = mMeshData->GetAnimator();
+		animator->Play(L"Idle");
+
 	}
 	void AshinaSoldier::Update()
 	{

--- a/Engine_SOURCE/yaAshinaSoldier.h
+++ b/Engine_SOURCE/yaAshinaSoldier.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "yaMonsterBase.h"
+
+namespace ya
+{
+	class AshinaSoldier:
+		public MonsterBase
+	{
+	public:
+		AshinaSoldier();
+		~AshinaSoldier();
+	public:
+
+		virtual void Initialize() override;
+		virtual void Update() override;
+		virtual void FixedUpdate() override;
+		virtual void Render() override;
+
+		virtual void DeathBlow() override;
+
+		void OnCollisionEnter(Collider2D* collider) override;
+		void OnCollisionStay(Collider2D* collider)  override;
+		void OnCollisionExit(Collider2D* collider)  override;
+	};
+}

--- a/Engine_SOURCE/yaEnums.h
+++ b/Engine_SOURCE/yaEnums.h
@@ -61,11 +61,11 @@ namespace ya::enums
 		Mesh,
 		Texture,
 		Material,
-		Animation,
 		Sound,
 		/*Font,*/
 		Prefab,
 		MeshData,
+		AnimationData,
 		GraphicShader,
 		ComputeShader,
 		AudioClip,

--- a/Engine_SOURCE/yaMeshData.cpp
+++ b/Engine_SOURCE/yaMeshData.cpp
@@ -12,7 +12,7 @@
 #include "yaBoundarySphere.h"
 #include "yaScene.h"
 #include "StrConverter.h"
-
+#include "yaAnimationData.h"
 namespace ya
 {
 	MeshData::MeshData()
@@ -20,7 +20,6 @@ namespace ya
 		, mAnimationClipCount(0)
 		, mIFrameCount(0)
 		, mBoneOffset(nullptr)
-		, mAnimationOffset(Vector3::Zero)
 		, mbBoundarySphere(false)
 	{
 	}
@@ -584,143 +583,43 @@ namespace ya
 
 	HRESULT MeshData::AnimationLoad(const std::wstring& path, FILE* file, bool bLast)
 	{
-		std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
+		if (mAnimationData == nullptr)
+			mAnimationData = std::make_shared<AnimationData>();
+		if (bLast)
+		{		//Find 애니메이션 데이터
+			std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
 
-		std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
+			std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
 
-		std::filesystem::path parentPath = strPath;
-		parentPath = parentPath.parent_path().parent_path();
-		parentPath += L"\\AnimationData\\";
+			std::filesystem::path parentPath = strPath;
+			parentPath = parentPath.parent_path().parent_path();
+			parentPath += L"\\AnimationData\\";
 
-		CurparentPath /= parentPath;
+			CurparentPath /= parentPath;
 
-		std::wstring name = std::filesystem::path(path).stem();
-		name += L".animationdata";
+			std::wstring name = std::filesystem::path(path).stem();
+			name += L".animationdata";
 
-		CurparentPath += name;
+			CurparentPath += name;
 
-		std::wstring fullPath = CurparentPath;
+			std::wstring fullPath = CurparentPath;
+			std::wstring key = fullPath;
+			std::shared_ptr<AnimationData> resource = Resources::Find<AnimationData>(key);
 
-		file = nullptr;
-		_wfopen_s(&file, fullPath.c_str(), L"rb");
-		if (file == nullptr)
-			return S_FALSE;
-
-		//본 사이즈 
-		UINT boneSize = 0;
-		fread(&boneSize, sizeof(UINT), 1, file);	
-
-
-		//애니 클립 사이즈 저장
-		UINT AnimClipSize = 0;
-		fread(&AnimClipSize, sizeof(UINT), 1, file);
-		mAnimationClipCount += AnimClipSize;
-
-		std::vector<BoneAnimationClip> animClip;
-
-		animClip.resize(AnimClipSize);
-		for (size_t i = 0; i < AnimClipSize; i++)
-		{
-			LoadWString(animClip[i].name, file);
-
-			fread(&animClip[i].startTime, sizeof(double), 1, file);
-			fread(&animClip[i].endTime, sizeof(double), 1, file);
-			fread(&animClip[i].timeLength, sizeof(double), 1, file);
-			fread(&animClip[i].mode, sizeof(int), 1, file);
-			fread(&animClip[i].updateTime, sizeof(float), 1, file);
-			fread(&animClip[i].startFrame, sizeof(int), 1, file);
-			fread(&animClip[i].endFrame, sizeof(int), 1, file);
-			fread(&animClip[i].frameLength, sizeof(int), 1, file);			
-		}
-
-		// 본정보들 전부 저장	
-		//UINT iFrameCount = 0;
-		mBones.resize(boneSize);
-		for (size_t i = 0; i < boneSize; i++)
-		{
-			LoadWString(mBones[i].name, file);
-			fread(&mBones[i].depth, sizeof(int), 1, file);
-			fread(&mBones[i].parentIdx, sizeof(int), 1, file);
-			fread(&mBones[i].bone, sizeof(Matrix), 1, file);
-			fread(&mBones[i].offset, sizeof(Matrix), 1, file);
-
-			std::vector<std::vector<BoneKeyFrame>> keyFrames;
-			keyFrames.resize(AnimClipSize);
-			//mBones[i].keyFrames.resize(AnimClipSize);
-			for (size_t j = 0; j < AnimClipSize; j++)
-			{				
-				UINT boneKeyFramesSize;
-				fread(&boneKeyFramesSize, sizeof(UINT), 1, file);
-				
-				keyFrames[j].resize(boneKeyFramesSize);
-
-				for (UINT k = 0; k < keyFrames[j].size(); k++)
-				{
-					fread(&keyFrames[j][k].time, sizeof(double), 1, file);
-					fread(&keyFrames[j][k].frame, sizeof(int), 1, file);
-					fread(&keyFrames[j][k].translate, sizeof(Vector3), 1, file);
-					fread(&keyFrames[j][k].scale, sizeof(Vector3), 1, file);
-					fread(&keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
-				}
-				mIFrameCount = max(mIFrameCount, (UINT)keyFrames[j].size());
-
-				/*
-				mBones[i].keyFrames[j].resize(boneKeyFramesSize);
-				for (UINT k = 0; k < mBones[i].keyFrames[j].size(); k++)
-				{
-					fread(&mBones[i].keyFrames[j][k].time, sizeof(double), 1, file);
-					fread(&mBones[i].keyFrames[j][k].frame, sizeof(int), 1, file);
-					fread(&mBones[i].keyFrames[j][k].translate, sizeof(Vector3), 1, file);
-					fread(&mBones[i].keyFrames[j][k].scale, sizeof(Vector3), 1, file);
-					fread(&mBones[i].keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
-				}
-				iFrameCount = max(iFrameCount, (UINT)mBones[i].keyFrames[j].size());	
-				*/		
-			}			
-			mBones[i].keyFrames.insert(mBones[i].keyFrames.end(), keyFrames.begin(), keyFrames.end());
-		}
-
-		fclose(file);
-
-		mAnimClip.insert(mAnimClip.end(), animClip.begin(), animClip.end());
-
-		if(bLast)
-		{
-			std::vector<std::vector<BoneFrameTransform>> vecFrameTrans;
-			vecFrameTrans.resize(mAnimationClipCount);
-
-			for (size_t i = 0; i < mBones.size(); ++i)
+			if (resource != nullptr)
 			{
-				for (size_t k = 0; k < mAnimationClipCount; k++)
-				{
-					vecFrameTrans[k].resize((UINT)mBones.size() * mIFrameCount);
-					for (size_t j = 0; j < mBones[i].keyFrames[k].size(); ++j)
-					{
-						vecFrameTrans[k][(UINT)mBones.size() * j + i]
-							= BoneFrameTransform
-						{
-							Vector4(mBones[i].keyFrames[k][j].translate.x + mAnimationOffset.x
-								, mBones[i].keyFrames[k][j].translate.y + mAnimationOffset.y
-								, mBones[i].keyFrames[k][j].translate.z + mAnimationOffset.z , 0.f)
-							, Vector4(mBones[i].keyFrames[k][j].scale.x
-								, mBones[i].keyFrames[k][j].scale.y
-								, mBones[i].keyFrames[k][j].scale.z, 0.f)
-							, mBones[i].keyFrames[k][j].rotation
-						};
-					}
-				}
+				mAnimationData = resource;
 			}
-
-			for (size_t i = 0; i < mAnimationClipCount; i++)
+			else
 			{
-				graphics::StructedBuffer* boneFrameData = new graphics::StructedBuffer();
-				boneFrameData->Create(sizeof(BoneFrameTransform), (UINT)mBones.size() * mIFrameCount
-					, eSRVType::SRV, vecFrameTrans[i].data(), false);
-				PushBackBoneFrameData(boneFrameData);
-			}	
+				mAnimationData->LoadFin(path);
+			}
 		}
-		
+		else
+			mAnimationData->LoadNotFin(path);
+
 		return S_OK;
+
 	}
 
 
@@ -760,15 +659,15 @@ namespace ya
 			meshObject->PushBackObject(gameObj);
 			mChildObjects.push_back(gameObj);
 
-			if (mAnimationClipCount > 0)
+			if (mAnimationData != nullptr)
 			{
 				BoneAnimator* animator = gameObj->AddComponent<BoneAnimator>();
 
 				if (i == 0)
 				{
 					mRepresentBoneAnimator = animator;		
-					animator->SetBones(&mBones);
-					animator->SetAnimaitionClip(&mAnimClip);
+					animator->SetBones(GetBones());
+					animator->SetAnimaitionClip(GetAnimClips());
 				}
 				else
 					animator->SetParentAnimator(mRepresentBoneAnimator);
@@ -813,6 +712,26 @@ namespace ya
 	std::function<void()>& MeshData::GetAnimationFrameEvent(const std::wstring& name, UINT index)
 	{
 		return mRepresentBoneAnimator->GetFrameEvent(name, index);
+	}
+
+	std::vector<BoneMatrix>* MeshData::GetBones()
+	{
+		return mAnimationData->GetBones();
+	}
+
+	std::vector<BoneAnimationClip>* MeshData::GetAnimClips()
+	{
+		return mAnimationData->GetAnimClips();
+	}
+
+	UINT MeshData::GetAnimationClipCount()
+	{
+		return mAnimationData->GetAnimationClipCount();
+	}
+
+	std::vector<graphics::StructedBuffer*> MeshData::GetBoneFrameData()
+	{
+		return mAnimationData->GetBoneFrameDataVector();
 	}
 
 

--- a/Engine_SOURCE/yaMeshData.cpp
+++ b/Engine_SOURCE/yaMeshData.cpp
@@ -12,7 +12,7 @@
 #include "yaBoundarySphere.h"
 #include "yaScene.h"
 #include "StrConverter.h"
-
+#include "yaAnimationData.h"
 namespace ya
 {
 	MeshData::MeshData()
@@ -20,7 +20,6 @@ namespace ya
 		, mAnimationClipCount(0)
 		, mIFrameCount(0)
 		, mBoneOffset(nullptr)
-		, mAnimationOffset(Vector3::Zero)
 		, mbBoundarySphere(false)
 	{
 	}
@@ -207,9 +206,7 @@ namespace ya
 		std::vector<Bone*>& vecBone = loader.GetBones();
 		UINT iFrameCount = 0;
 		//메쉬 데이터에 저장된 본
-		std::vector<BoneMatrix>* meshBones = GetBones();
-		UINT animCount = GetAnimationClipCount();
-		SetAnimationClipCount(animCount + 1);
+		std::vector<BoneMatrix>* meshBones = &mBones;
 
 		//애니메이션 데이터의 본
 		
@@ -239,13 +236,13 @@ namespace ya
 						tKeyframe.rotation.z = (float)vecBone[i]->keyFrames[k].transform.GetQ().mData[2];
 						tKeyframe.rotation.w = (float)vecBone[i]->keyFrames[k].transform.GetQ().mData[3];
 
-						meshBones->at(j).keyFrames[animCount].push_back(tKeyframe);
+						meshBones->at(j).keyFrames[mAnimationClipCount].push_back(tKeyframe);
 						//mBonekeyFrame.push_back(tKeyframe);
 					}
 					break;
 				}
 			}
-			iFrameCount = max(iFrameCount, (UINT)meshBones->at(j).keyFrames[animCount].size());
+			iFrameCount = max(iFrameCount, (UINT)meshBones->at(j).keyFrames[mAnimationClipCount].size());
 		}
 
 		mBones;
@@ -266,7 +263,7 @@ namespace ya
 			tClip.frameLength = tClip.endFrame - tClip.startFrame;
 			tClip.mode = vecAnimClip[i]->mode;
 
-			PushBackAnimClip(tClip);
+			mAnimClip.push_back(tClip);
 		}
 
 		// Animation 이 있는 Mesh 경우 structuredbuffer 만들어두기
@@ -275,18 +272,18 @@ namespace ya
 
 		for (size_t i = 0; i < meshBones->size(); ++i)
 		{
-			for (size_t j = 0; j < meshBones->at(i).keyFrames[animCount].size(); ++j)
+			for (size_t j = 0; j < meshBones->at(i).keyFrames[mAnimationClipCount].size(); ++j)
 			{
 				vecFrameTrans[(UINT)meshBones->size() * j + i]
 					= BoneFrameTransform
 				{
-					Vector4(meshBones->at(i).keyFrames[animCount][j].translate.x
-						, meshBones->at(i).keyFrames[animCount][j].translate.y
-						, meshBones->at(i).keyFrames[animCount][j].translate.z, 0.f)
-					, Vector4(meshBones->at(i).keyFrames[animCount][j].scale.x
-						, meshBones->at(i).keyFrames[animCount][j].scale.y
-						, meshBones->at(i).keyFrames[animCount][j].scale.z, 0.f)
-					, meshBones->at(i).keyFrames[animCount][j].rotation
+					Vector4(meshBones->at(i).keyFrames[mAnimationClipCount][j].translate.x
+						, meshBones->at(i).keyFrames[mAnimationClipCount][j].translate.y
+						, meshBones->at(i).keyFrames[mAnimationClipCount][j].translate.z, 0.f)
+					, Vector4(meshBones->at(i).keyFrames[mAnimationClipCount][j].scale.x
+						, meshBones->at(i).keyFrames[mAnimationClipCount][j].scale.y
+						, meshBones->at(i).keyFrames[mAnimationClipCount][j].scale.z, 0.f)
+					, meshBones->at(i).keyFrames[mAnimationClipCount][j].rotation
 				};						
 			}
 		}
@@ -296,13 +293,14 @@ namespace ya
 		graphics::StructedBuffer* boneFrameData = new graphics::StructedBuffer();
 		boneFrameData->Create(sizeof(BoneFrameTransform), (UINT)meshBones->size() * iFrameCount
 			, eSRVType::SRV, vecFrameTrans.data(), false);
-		PushBackBoneFrameData(boneFrameData);
+		mBoneFrameDataVector.push_back(boneFrameData);
 
 		
 		//AnimationSave(path, name);
 
 
-		
+		mAnimationClipCount += 1;
+
 		loader.Release();
 	}
 
@@ -584,143 +582,45 @@ namespace ya
 
 	HRESULT MeshData::AnimationLoad(const std::wstring& path, FILE* file, bool bLast)
 	{
-		std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
+		if (mAnimationData == nullptr)
+			mAnimationData = std::make_shared<AnimationData>();
+		if (bLast)
+		{		//Find 애니메이션 데이터
+			std::string strPath = StrConverter::ConvertUnicodeToUTF8(path);
 
-		std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
+			std::filesystem::path CurparentPath = std::fs::absolute(gResPath);
 
-		std::filesystem::path parentPath = strPath;
-		parentPath = parentPath.parent_path().parent_path();
-		parentPath += L"\\AnimationData\\";
+			std::filesystem::path parentPath = strPath;
+			parentPath = parentPath.parent_path().parent_path();
+			parentPath += L"\\AnimationData\\";
 
-		CurparentPath /= parentPath;
+			CurparentPath /= parentPath;
 
-		std::wstring name = std::filesystem::path(path).stem();
-		name += L".animationdata";
+			std::wstring name = std::filesystem::path(path).stem();
+			name += L".animationdata";
 
-		CurparentPath += name;
+			CurparentPath += name;
 
-		std::wstring fullPath = CurparentPath;
+			std::wstring fullPath = CurparentPath;
+			std::wstring key = fullPath;
+			std::shared_ptr<AnimationData> resource = Resources::Find<AnimationData>(key);
 
-		file = nullptr;
-		_wfopen_s(&file, fullPath.c_str(), L"rb");
-		if (file == nullptr)
-			return S_FALSE;
-
-		//본 사이즈 
-		UINT boneSize = 0;
-		fread(&boneSize, sizeof(UINT), 1, file);	
-
-
-		//애니 클립 사이즈 저장
-		UINT AnimClipSize = 0;
-		fread(&AnimClipSize, sizeof(UINT), 1, file);
-		mAnimationClipCount += AnimClipSize;
-
-		std::vector<BoneAnimationClip> animClip;
-
-		animClip.resize(AnimClipSize);
-		for (size_t i = 0; i < AnimClipSize; i++)
-		{
-			LoadWString(animClip[i].name, file);
-
-			fread(&animClip[i].startTime, sizeof(double), 1, file);
-			fread(&animClip[i].endTime, sizeof(double), 1, file);
-			fread(&animClip[i].timeLength, sizeof(double), 1, file);
-			fread(&animClip[i].mode, sizeof(int), 1, file);
-			fread(&animClip[i].updateTime, sizeof(float), 1, file);
-			fread(&animClip[i].startFrame, sizeof(int), 1, file);
-			fread(&animClip[i].endFrame, sizeof(int), 1, file);
-			fread(&animClip[i].frameLength, sizeof(int), 1, file);			
-		}
-
-		// 본정보들 전부 저장	
-		//UINT iFrameCount = 0;
-		mBones.resize(boneSize);
-		for (size_t i = 0; i < boneSize; i++)
-		{
-			LoadWString(mBones[i].name, file);
-			fread(&mBones[i].depth, sizeof(int), 1, file);
-			fread(&mBones[i].parentIdx, sizeof(int), 1, file);
-			fread(&mBones[i].bone, sizeof(Matrix), 1, file);
-			fread(&mBones[i].offset, sizeof(Matrix), 1, file);
-
-			std::vector<std::vector<BoneKeyFrame>> keyFrames;
-			keyFrames.resize(AnimClipSize);
-			//mBones[i].keyFrames.resize(AnimClipSize);
-			for (size_t j = 0; j < AnimClipSize; j++)
-			{				
-				UINT boneKeyFramesSize;
-				fread(&boneKeyFramesSize, sizeof(UINT), 1, file);
-				
-				keyFrames[j].resize(boneKeyFramesSize);
-
-				for (UINT k = 0; k < keyFrames[j].size(); k++)
-				{
-					fread(&keyFrames[j][k].time, sizeof(double), 1, file);
-					fread(&keyFrames[j][k].frame, sizeof(int), 1, file);
-					fread(&keyFrames[j][k].translate, sizeof(Vector3), 1, file);
-					fread(&keyFrames[j][k].scale, sizeof(Vector3), 1, file);
-					fread(&keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
-				}
-				mIFrameCount = max(mIFrameCount, (UINT)keyFrames[j].size());
-
-				/*
-				mBones[i].keyFrames[j].resize(boneKeyFramesSize);
-				for (UINT k = 0; k < mBones[i].keyFrames[j].size(); k++)
-				{
-					fread(&mBones[i].keyFrames[j][k].time, sizeof(double), 1, file);
-					fread(&mBones[i].keyFrames[j][k].frame, sizeof(int), 1, file);
-					fread(&mBones[i].keyFrames[j][k].translate, sizeof(Vector3), 1, file);
-					fread(&mBones[i].keyFrames[j][k].scale, sizeof(Vector3), 1, file);
-					fread(&mBones[i].keyFrames[j][k].rotation, sizeof(Vector4), 1, file);
-				}
-				iFrameCount = max(iFrameCount, (UINT)mBones[i].keyFrames[j].size());	
-				*/		
-			}			
-			mBones[i].keyFrames.insert(mBones[i].keyFrames.end(), keyFrames.begin(), keyFrames.end());
-		}
-
-		fclose(file);
-
-		mAnimClip.insert(mAnimClip.end(), animClip.begin(), animClip.end());
-
-		if(bLast)
-		{
-			std::vector<std::vector<BoneFrameTransform>> vecFrameTrans;
-			vecFrameTrans.resize(mAnimationClipCount);
-
-			for (size_t i = 0; i < mBones.size(); ++i)
+			if (resource != nullptr)
 			{
-				for (size_t k = 0; k < mAnimationClipCount; k++)
-				{
-					vecFrameTrans[k].resize((UINT)mBones.size() * mIFrameCount);
-					for (size_t j = 0; j < mBones[i].keyFrames[k].size(); ++j)
-					{
-						vecFrameTrans[k][(UINT)mBones.size() * j + i]
-							= BoneFrameTransform
-						{
-							Vector4(mBones[i].keyFrames[k][j].translate.x + mAnimationOffset.x
-								, mBones[i].keyFrames[k][j].translate.y + mAnimationOffset.y
-								, mBones[i].keyFrames[k][j].translate.z + mAnimationOffset.z , 0.f)
-							, Vector4(mBones[i].keyFrames[k][j].scale.x
-								, mBones[i].keyFrames[k][j].scale.y
-								, mBones[i].keyFrames[k][j].scale.z, 0.f)
-							, mBones[i].keyFrames[k][j].rotation
-						};
-					}
-				}
+				mAnimationData = resource;
 			}
-
-			for (size_t i = 0; i < mAnimationClipCount; i++)
+			else
 			{
-				graphics::StructedBuffer* boneFrameData = new graphics::StructedBuffer();
-				boneFrameData->Create(sizeof(BoneFrameTransform), (UINT)mBones.size() * mIFrameCount
-					, eSRVType::SRV, vecFrameTrans[i].data(), false);
-				PushBackBoneFrameData(boneFrameData);
-			}	
+				mAnimationData->LoadFin(path);
+				Resources::Insert<AnimationData>(fullPath, mAnimationData);
+
+			}
 		}
-		
+		else
+			mAnimationData->LoadNotFin(path);
+
 		return S_OK;
+
 	}
 
 
@@ -760,15 +660,15 @@ namespace ya
 			meshObject->PushBackObject(gameObj);
 			mChildObjects.push_back(gameObj);
 
-			if (mAnimationClipCount > 0)
+			if (mAnimationData != nullptr || mAnimationClipCount > 0)
 			{
 				BoneAnimator* animator = gameObj->AddComponent<BoneAnimator>();
 
 				if (i == 0)
 				{
 					mRepresentBoneAnimator = animator;		
-					animator->SetBones(&mBones);
-					animator->SetAnimaitionClip(&mAnimClip);
+					animator->SetBones(GetBones());
+					animator->SetAnimaitionClip(GetAnimClips());
 				}
 				else
 					animator->SetParentAnimator(mRepresentBoneAnimator);
@@ -813,6 +713,38 @@ namespace ya
 	std::function<void()>& MeshData::GetAnimationFrameEvent(const std::wstring& name, UINT index)
 	{
 		return mRepresentBoneAnimator->GetFrameEvent(name, index);
+	}
+
+	std::vector<BoneMatrix>* MeshData::GetBones()
+	{
+		if (mAnimationData)
+			return mAnimationData->GetBones();
+		else
+			return &mBones;
+	}
+
+	std::vector<BoneAnimationClip>* MeshData::GetAnimClips()
+	{
+		if (mAnimationData)
+			return mAnimationData->GetAnimClips();
+		else
+			return &mAnimClip;
+	}
+
+	UINT MeshData::GetAnimationClipCount()
+	{
+		if (mAnimationData)
+			return mAnimationData->GetAnimationClipCount();
+		else
+			return mAnimationClipCount;
+	}
+
+	std::vector<graphics::StructedBuffer*> MeshData::GetBoneFrameData()
+	{
+		if (mAnimationData)
+			return mAnimationData->GetBoneFrameDataVector();
+		else
+			return mBoneFrameDataVector;
 	}
 
 

--- a/Engine_SOURCE/yaMeshData.h
+++ b/Engine_SOURCE/yaMeshData.h
@@ -8,6 +8,7 @@
 namespace ya
 {
 	class Scene;
+	class AnimationData;
 	class MeshData : public Resource
 	{
 	public:
@@ -39,25 +40,23 @@ namespace ya
 		std::function<void()>& GetAnimationFrameEvent(const std::wstring& name, UINT index);	
 
 
-		std::vector<graphics::StructedBuffer*> GetBoneFrameData() { return mBoneFrameDataVector; }
 		graphics::StructedBuffer* GetBoneOffset() { return mBoneOffset; }
 
 		//Save --------- public
-		std::vector<BoneMatrix>* GetBones() { return &mBones; }
-		std::vector<BoneAnimationClip> GetAnimClips() { return mAnimClip; }
+		std::vector<BoneMatrix>* GetBones();
+		std::vector<BoneAnimationClip>* GetAnimClips();
+		UINT GetAnimationClipCount();
+		std::vector<graphics::StructedBuffer*> GetBoneFrameData();
+
+		void PushBackAnimClip(BoneAnimationClip& clip) { mAnimClip.push_back(clip); }
+		void SetAnimationClipCount(UINT num) { mAnimationClipCount = num; }
+		void PushBackBoneFrameData(graphics::StructedBuffer* buffer) { mBoneFrameDataVector.push_back(buffer); }
+
 
 		std::vector<std::shared_ptr<Mesh>> GetMeshs() { return mMeshes; }
 
 		std::vector<std::vector<std::shared_ptr<Material>>> GetMaterialsVec() { return mMaterialsVec; }
-
-		void PushBackAnimClip(BoneAnimationClip& clip) { mAnimClip.push_back(clip); }
-
-		void PushBackBoneFrameData(graphics::StructedBuffer* buffer) { mBoneFrameDataVector.push_back(buffer); }
-
 		void SetBoneOffset(graphics::StructedBuffer* buffer) { mBoneOffset = buffer; }
-
-		void SetAnimationClipCount(UINT num) { mAnimationClipCount = num; }
-		UINT GetAnimationClipCount() { return mAnimationClipCount; }
 		class BoneAnimator* GetAnimator() { return mRepresentBoneAnimator; }
 		MeshObject* GetMeshObject() { return mMeshObject; }
 		std::vector<GameObject*> GetChildObjects() { return mChildObjects; }
@@ -66,8 +65,6 @@ namespace ya
 
 		void SaveWString(const std::wstring& _str, FILE* _pFile);
 		void LoadWString(std::wstring& _str, FILE* _pFile);
-
-		void SetAnimationOffset(Vector3 offset) { mAnimationOffset = offset; }
 		
 		
 		void SetBoundarySphere(bool b) { mbBoundarySphere = b; }
@@ -80,26 +77,26 @@ namespace ya
 		std::vector<GameObject*> mChildObjects;
 
 		std::wstring mFullPath;
+		graphics::StructedBuffer* mBoneOffset; // 각 뼈의 offset 행렬 () 각뼈의 위치를 TPOSE로 되돌리는 행렬
 
 		//3D Animation 정보
 		std::vector<BoneAnimationClip> mAnimClip;
 		std::vector<BoneMatrix> mBones;
-	
 		std::vector<graphics::StructedBuffer*> mBoneFrameDataVector; // 전체 본 프레임 정보 ( 크기, 이름, 회전) 프레임 갯수만큼
-		graphics::StructedBuffer* mBoneOffset; // 각 뼈의 offset 행렬 () 각뼈의 위치를 TPOSE로 되돌리는 행렬
-
 		UINT mAnimationClipCount;
 		UINT mIFrameCount;
 
+
+
 		Vector3 mMeshCenter;
 		float mBoundarySphereRadius;
-		
 		class BoneAnimator* mRepresentBoneAnimator;
 		MeshObject* mMeshObject;
 
-		Vector3 mAnimationOffset;
 		//Frustum Culling 여부
 		bool mbBoundarySphere;
+
+		std::shared_ptr<AnimationData> mAnimationData;
 
 	};
 }

--- a/Engine_SOURCE/yaMeshData.h
+++ b/Engine_SOURCE/yaMeshData.h
@@ -8,6 +8,7 @@
 namespace ya
 {
 	class Scene;
+	class AnimationData;
 	class MeshData : public Resource
 	{
 	public:
@@ -39,25 +40,20 @@ namespace ya
 		std::function<void()>& GetAnimationFrameEvent(const std::wstring& name, UINT index);	
 
 
-		std::vector<graphics::StructedBuffer*> GetBoneFrameData() { return mBoneFrameDataVector; }
 		graphics::StructedBuffer* GetBoneOffset() { return mBoneOffset; }
 
 		//Save --------- public
-		std::vector<BoneMatrix>* GetBones() { return &mBones; }
-		std::vector<BoneAnimationClip> GetAnimClips() { return mAnimClip; }
+		std::vector<BoneMatrix>* GetBones();
+		std::vector<BoneAnimationClip>* GetAnimClips();
+		UINT GetAnimationClipCount();
+		std::vector<graphics::StructedBuffer*> GetBoneFrameData();
+
+
 
 		std::vector<std::shared_ptr<Mesh>> GetMeshs() { return mMeshes; }
 
 		std::vector<std::vector<std::shared_ptr<Material>>> GetMaterialsVec() { return mMaterialsVec; }
-
-		void PushBackAnimClip(BoneAnimationClip& clip) { mAnimClip.push_back(clip); }
-
-		void PushBackBoneFrameData(graphics::StructedBuffer* buffer) { mBoneFrameDataVector.push_back(buffer); }
-
 		void SetBoneOffset(graphics::StructedBuffer* buffer) { mBoneOffset = buffer; }
-
-		void SetAnimationClipCount(UINT num) { mAnimationClipCount = num; }
-		UINT GetAnimationClipCount() { return mAnimationClipCount; }
 		class BoneAnimator* GetAnimator() { return mRepresentBoneAnimator; }
 		MeshObject* GetMeshObject() { return mMeshObject; }
 		std::vector<GameObject*> GetChildObjects() { return mChildObjects; }
@@ -66,8 +62,6 @@ namespace ya
 
 		void SaveWString(const std::wstring& _str, FILE* _pFile);
 		void LoadWString(std::wstring& _str, FILE* _pFile);
-
-		void SetAnimationOffset(Vector3 offset) { mAnimationOffset = offset; }
 		
 		
 		void SetBoundarySphere(bool b) { mbBoundarySphere = b; }
@@ -80,26 +74,26 @@ namespace ya
 		std::vector<GameObject*> mChildObjects;
 
 		std::wstring mFullPath;
+		graphics::StructedBuffer* mBoneOffset; // 각 뼈의 offset 행렬 () 각뼈의 위치를 TPOSE로 되돌리는 행렬
 
 		//3D Animation 정보
 		std::vector<BoneAnimationClip> mAnimClip;
 		std::vector<BoneMatrix> mBones;
-	
 		std::vector<graphics::StructedBuffer*> mBoneFrameDataVector; // 전체 본 프레임 정보 ( 크기, 이름, 회전) 프레임 갯수만큼
-		graphics::StructedBuffer* mBoneOffset; // 각 뼈의 offset 행렬 () 각뼈의 위치를 TPOSE로 되돌리는 행렬
-
 		UINT mAnimationClipCount;
 		UINT mIFrameCount;
 
+
+
 		Vector3 mMeshCenter;
 		float mBoundarySphereRadius;
-		
 		class BoneAnimator* mRepresentBoneAnimator;
 		MeshObject* mMeshObject;
 
-		Vector3 mAnimationOffset;
 		//Frustum Culling 여부
 		bool mbBoundarySphere;
+
+		std::shared_ptr<AnimationData> mAnimationData;
 
 	};
 }

--- a/Engine_SOURCE/yaPlayScene.cpp
+++ b/Engine_SOURCE/yaPlayScene.cpp
@@ -18,10 +18,8 @@
 
 #include "yaMonster.h"
 #include "yaSwordMan.h"
-#include "yaMusketeerman.h"
-#include "yaSwordsman.h"
 #include "yaTenzen.h"
-#include "yaRedOgre.h"
+#include "yaAshinaSoldier.h"
 
 #include "MapObjects.h"
 #include "yaBoundarySphere.h"
@@ -241,7 +239,8 @@ namespace ya
 			m->Init(this);
 		}
 		//Resources::Load<MeshData>(L"test", L"Player/Mesh/o000100.fbx");
-		object::Instantiate<SwordMan>(eLayerType::Monster, this);
+		object::Instantiate<Tenzen>(eLayerType::Monster, this);
+		object::Instantiate<Tenzen>(eLayerType::Monster, this);
 
 		Scene::Initialize();
 	}

--- a/Engine_SOURCE/yaPlayScene.cpp
+++ b/Engine_SOURCE/yaPlayScene.cpp
@@ -239,7 +239,7 @@ namespace ya
 			m->Init(this);
 		}
 		//Resources::Load<MeshData>(L"test", L"Player/Mesh/o000100.fbx");
-		object::Instantiate<Tenzen>(eLayerType::Monster, this);
+		//object::Instantiate<AshinaSoldier>(eLayerType::Monster, this);
 		object::Instantiate<Tenzen>(eLayerType::Monster, this);
 
 		Scene::Initialize();

--- a/Engine_SOURCE/yaSceneManager.cpp
+++ b/Engine_SOURCE/yaSceneManager.cpp
@@ -22,7 +22,7 @@ namespace ya
 
 		mScenes[(UINT)eSceneType::Play] = new PlayScene();
 		mScenes[(UINT)eSceneType::Play]->SetName(L"PlayScene");
-		mScenes[(UINT)eSceneType::Play]->SetThreadLoad(true);
+		mScenes[(UINT)eSceneType::Play]->SetThreadLoad(false);
 		//mScenes[(UINT)eSceneType::Play]->GetCallBack() = std::bind(SceneManager::LoadScene, eSceneType::Play);
 
 		for (Scene* scene : mScenes)
@@ -41,7 +41,7 @@ namespace ya
 			}
 		}
 
-		mActiveScene = mScenes[(UINT)eSceneType::Title];
+		mActiveScene = mScenes[(UINT)eSceneType::Play];
 	}
 
 	void SceneManager::Update()

--- a/Engine_SOURCE/yaSceneManager.cpp
+++ b/Engine_SOURCE/yaSceneManager.cpp
@@ -22,7 +22,7 @@ namespace ya
 
 		mScenes[(UINT)eSceneType::Play] = new PlayScene();
 		mScenes[(UINT)eSceneType::Play]->SetName(L"PlayScene");
-		mScenes[(UINT)eSceneType::Play]->SetThreadLoad(false);
+		mScenes[(UINT)eSceneType::Play]->SetThreadLoad(true);
 		//mScenes[(UINT)eSceneType::Play]->GetCallBack() = std::bind(SceneManager::LoadScene, eSceneType::Play);
 
 		for (Scene* scene : mScenes)
@@ -41,7 +41,7 @@ namespace ya
 			}
 		}
 
-		mActiveScene = mScenes[(UINT)eSceneType::Play];
+		mActiveScene = mScenes[(UINT)eSceneType::Title];
 	}
 
 	void SceneManager::Update()


### PR DESCRIPTION
기존 애니메이션 데이터 활용 방식이
메쉬데이터 클래스에 애니메이션 데이터를 읽어서 전부 박아 넣는 식이였는데
이러면 문제가
오브젝트를 하나 생성할대마다 메쉬데이터에 애니메이션 데이터를 박아 넣게되어서
똑같은 잡 몹 10개를 생성할때 마다 애니메이션 데이터 10개만큼의 메모리를 사용하게 됨.

애니메이션 데이터 리소스를 참조하는 방식으로 변경함